### PR TITLE
fix(a11y): PR #221 review nits — ThemeToggle, ErrorBoundary, Filter drawer

### DIFF
--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,6 +1,8 @@
 import { Component, ErrorInfo, ReactNode } from 'react';
 import { Box, Button, Typography } from '@mui/material';
 
+import { RoutePaths } from '../../routes/routes.enum';
+
 // Global error boundary (5.5): catches render-time crashes so a broken page
 // shows a recovery prompt instead of a blank screen.
 
@@ -35,7 +37,7 @@ class ErrorBoundary extends Component<Props, State> {
         >
           <Typography variant="h4">Something went wrong</Typography>
           <Typography color="text.secondary">An unexpected error occurred. Try reloading the page.</Typography>
-          <Button variant="contained" onClick={(): void => window.location.assign('/')}>
+          <Button variant="contained" onClick={(): void => window.location.assign(RoutePaths.MAIN)}>
             Back to home
           </Button>
         </Box>

--- a/src/components/Filter/Filter.tsx
+++ b/src/components/Filter/Filter.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import CloseIcon from '@mui/icons-material/Close';
 import FilterListIcon from '@mui/icons-material/FilterList';
 
@@ -50,6 +50,18 @@ const FilterControls: React.FC<FilterControlsProps & { mobile?: boolean }> = ({
 
 const Filter: React.FC<Props> = ({ className, ...controls }) => {
   const [open, setOpen] = useState(false);
+  const closeRef = useRef<HTMLButtonElement>(null);
+
+  // a11y: Esc closes the drawer; focus moves to the close button on open
+  useEffect(() => {
+    if (!open) return undefined;
+    closeRef.current?.focus();
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('keydown', onKey);
+    return (): void => document.removeEventListener('keydown', onKey);
+  }, [open]);
 
   return (
     <>
@@ -65,10 +77,11 @@ const Filter: React.FC<Props> = ({ className, ...controls }) => {
 
       {/* mobile drawer */}
       {open && (
-        <div className="fixed inset-0 z-[1000] md:hidden">
+        <div className="fixed inset-0 z-[1000] md:hidden" role="dialog" aria-modal="true" aria-label="Filters">
           <div className="absolute inset-0 bg-black/40" onClick={(): void => setOpen(false)} aria-hidden />
           <div className="absolute inset-y-0 left-0 w-[85vw] max-w-sm overflow-y-auto bg-page p-4 shadow-xl">
             <button
+              ref={closeRef}
               type="button"
               aria-label="close"
               onClick={(): void => setOpen(false)}

--- a/src/components/ThemeToggle/ThemeToggle.tsx
+++ b/src/components/ThemeToggle/ThemeToggle.tsx
@@ -9,7 +9,7 @@ const ThemeToggle: React.FC = () => {
   const toggleDarkMode = useThemeStore((state) => state.toggleDarkMode);
 
   return (
-    <IconButton sx={{ color: 'primary.main' }} onClick={toggleDarkMode} color="inherit">
+    <IconButton aria-label="Toggle theme" sx={{ color: 'primary.main' }} onClick={toggleDarkMode} color="inherit">
       {darkMode ? <Brightness7Icon /> : <Brightness4Icon />}
     </IconButton>
   );


### PR DESCRIPTION
Small follow-up to the phase-5 part-1 review (PR #221). Addresses the three
actionable nits early instead of deferring all of them to phase 6.4:

- **ThemeToggle**: `aria-label="Toggle theme"` on the icon-only button (it's
  rendered twice in the merged Header — two unnamed buttons before this).
- **ErrorBoundary**: "Back to home" navigates to `RoutePaths.MAIN` instead of a
  hardcoded `'/'`.
- **Filter mobile drawer**: Escape-to-close, focus moves to the close button on
  open, `role="dialog"` + `aria-modal`. Full focus-trap/focus-return remains
  tracked under phase 6.4.

Gates: tsc (src+netlify), eslint 0 errors, 45 unit, e2e 11/11.