### PR TITLE
chore(phase-6.6): resolve dependency security alerts (swiper critical + moderates)

### DIFF
--- a/docs/refactor/phase-6.md
+++ b/docs/refactor/phase-6.md
@@ -20,15 +20,21 @@ Plan reference: REFACTORING_PLAN.md §5, "Фаза 6".
   - [x] `ErrorBoundary.tsx`: uses `RoutePaths.MAIN` — done early (PR #222)
 - [ ] **6.5** Docs: rewrite README (stack, setup, scripts), ADRs for key
       decisions (BFF, TanStack Query, UI kit choice).
-- [ ] **6.6** Dependency security: resolve the 6 open Dependabot alerts on
-      `develop` (snapshot 2026-06-17):
-  - **critical** — `swiper` (runtime dep, HeroCarousel/ProductCarousel): bump to
-    a patched version; smoke-test the carousels after.
-  - **high + low** — `esbuild` (transitive via Vite/Vitest): bump Vite/Vitest or
-    add an `overrides` pin.
-  - **moderate ×3** — `@opentelemetry/core` (already pinned via `overrides`),
-    `micromatch`, `yaml` (transitive, mostly netlify-cli/tooling): bump or pin.
-  - Re-run `npm audit` + `./scripts/verify.sh`; confirm Dependabot clears.
+- [~] **6.6** Dependency security (2026-06-18): `npm audit` went from
+      **1 critical + 14 moderate + 5 low → 9 low** (all one dev-only advisory).
+  - [x] **critical** `swiper` (runtime, HeroCarousel/ProductCarousel): bumped
+        `^10.1.0` → **`^12.2.0`** (2-major). typecheck/build/41 unit/11 e2e green;
+        both carousels visually verified (hero autoplay + product thumbnails),
+        look/behaviour 1:1.
+  - [x] **moderate** `@opentelemetry/core`, `micromatch`, `yaml`: cleared via
+        `overrides` (`@opentelemetry/core ^2.8.0`, `micromatch ^4.0.8`, `yaml ^2.8.3`).
+  - [~] **low** `esbuild` (9×, transitive via netlify-cli internals + Vite): NOT
+        patched. Accepted residual risk — advisory is a **Windows-only dev-server
+        file-read**, build-time only, **not in the production bundle**; we build on
+        Linux/Netlify. A global `esbuild` override risks breaking Vite 7/Vitest 4
+        (tightly version-coupled), and `netlify-cli@26` already pins its own copies.
+        Revisit when Vite/netlify-cli bump esbuild upstream.
+  - Verify on GitHub that Dependabot's tracked alerts clear after merge.
 - [ ] Final `PROGRESS.md` update; close the refactor.
 
 ## Exit criteria

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "react-dom": "^19.2.7",
         "react-hook-form": "^7.79.0",
         "react-router-dom": "^6.14.2",
-        "swiper": "^10.1.0",
+        "swiper": "^12.2.0",
         "zod": "^4.4.3",
         "zustand": "^5.0.14"
       },
@@ -6254,9 +6254,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -16588,36 +16588,12 @@
         }
       }
     },
-    "node_modules/lint-staged/node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/lint-staged/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/lint-staged/node_modules/yaml": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
-      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 14"
-      }
     },
     "node_modules/listhen": {
       "version": "1.10.0",
@@ -21792,17 +21768,17 @@
       }
     },
     "node_modules/swiper": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-10.3.1.tgz",
-      "integrity": "sha512-24Wk3YUdZHxjc9faID97GTu6xnLNia+adMt6qMTZG/HgdSUt4fS0REsGUXJOgpTED0Amh/j+gRGQxsLayJUlBQ==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-12.2.0.tgz",
+      "integrity": "sha512-K8uXsBZU6ME97Ia3xbBge8IRCnR1lOmIILzvY/jGVic7dSTQ530s3uO8RvXbPUtkkXLWIwmZLRPbtDxRWVAFdg==",
       "funding": [
         {
-          "type": "patreon",
-          "url": "https://www.patreon.com/swiperjs"
+          "type": "custom",
+          "url": "https://sponsors.nolimits4web.com"
         },
         {
-          "type": "open_collective",
-          "url": "http://opencollective.com/swiper"
+          "type": "github",
+          "url": "https://github.com/sponsors/nolimits4web"
         }
       ],
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^19.2.7",
     "react-hook-form": "^7.79.0",
     "react-router-dom": "^6.14.2",
-    "swiper": "^10.1.0",
+    "swiper": "^12.2.0",
     "zod": "^4.4.3",
     "zustand": "^5.0.14"
   },
@@ -71,6 +71,9 @@
     ]
   },
   "overrides": {
-    "@opentelemetry/api": "1.9.1"
+    "@opentelemetry/api": "1.9.1",
+    "@opentelemetry/core": "^2.8.0",
+    "micromatch": "^4.0.8",
+    "yaml": "^2.8.3"
   }
 }


### PR DESCRIPTION
First slice of **phase 6** — checklist **6.6** (dependency security). `npm audit`: **1 critical + 14 moderate + 5 low → 9 low** (one dev-only advisory).

### Fixed
- **critical** `swiper` `^10.1.0` → **`^12.2.0`** (prototype pollution GHSA-hmx5-qpq5-p643; runtime dep used by HeroCarousel + ProductCarousel).
  - Verified: typecheck + production build + 41 unit + 11 e2e green; both carousels visually checked (hero autoplay + product main/thumbnails) — look & behaviour 1:1.
- **moderate** `@opentelemetry/core`, `micromatch`, `yaml` → cleared via `overrides` (`^2.8.0` / `^4.0.8` / `^2.8.3`; transitive via netlify-cli / lint-staged).

### Residual (accepted, documented)
- **9 low** `esbuild` (GHSA-g7r4-m6w7-qqqr): Windows-only dev-server file-read, build-time only, **not in the production bundle** (we build on Linux/Netlify). A global `esbuild` override risks breaking Vite 7 / Vitest 4 (tightly version-coupled); netlify-cli@26 pins its own copies. Revisit when upstream bumps esbuild. See `docs/refactor/phase-6.md` §6.6.