### PR TITLE
docs(phase-6.5): rewrite README for modern stack + add ADRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,98 +1,112 @@
-# eCommerce-Application
+# YES CODE — eCommerce SPA
 
-## We made this project to sell our own merch.
+Single-page storefront for a merch shop, backed by [Commercetools](https://commercetools.com/).
+Originally an RS School 2023 project, migrated to a modern stack (see
+[`docs/refactor/`](docs/refactor/)).
 
-https://yes-code-merch.netlify.app/
+**Live:** https://yes-code-merch.netlify.app/
 
-## The technology stack used:
+## Stack
 
-- GitHub
-- GitHub Projects
-- CommerceTools
-- Webpack
-- React
-- TypeScript
-- ESLint
-- Prettier
-- Husky
-- Jest
+| Area        | Tech                                                                 |
+| ----------- | -------------------------------------------------------------------- |
+| Build       | **Vite 7**                                                           |
+| UI          | **React 19** · **TypeScript 5.9** (strict)                           |
+| Server state| **TanStack Query 5**                                                 |
+| Client state| **Zustand 5** (theme, auth)                                          |
+| Forms       | **react-hook-form** + **zod 4**                                      |
+| Commerce SDK| **@commercetools/ts-client v4** + a small **BFF** (Netlify Functions)|
+| Styling     | **Tailwind CSS 4** + **Radix UI** primitives + **lucide-react** icons|
+| Carousels   | **Swiper**                                                           |
+| Routing     | **react-router-dom 6** (route-level code splitting)                  |
+| Tests       | **Vitest** (unit) · **Playwright** (e2e)                             |
+| Tooling     | **ESLint 9** (flat config) · Prettier · Husky + lint-staged          |
 
-## Libraries used:
+## Architecture
 
-- Material UI
-- Classnames
-- Formik
-- Jsdom
-- Mobx
-- React-router-dom
-- Sass
-- Swiper
-- Yup
+The browser bundle never holds the Commercetools client secret. Auth/token
+exchange runs server-side in **Netlify Functions** (`netlify/functions/*`, the
+"BFF"); the SPA talks to those functions and to the CT API with the resulting
+token. See [ADR-0001](docs/adr/0001-bff-for-commercetools-auth.md).
 
-## Key pages in the application include:
+```
+src/
+  pages/        route screens (lazy-loaded)
+  components/   UI components + baseComponents/ (shared primitives, RHF adapters)
+  queries/      TanStack Query hooks (catalog, cart, categories, auth)
+  stores/       Zustand stores + cart/product helpers
+  schemas/      zod form schemas + validation rules
+  shared/       cross-cutting libs (cn, useMediaQuery, …)
+  services/     CT client setup
+  styles/       tailwind.css (the single styling entry)
+netlify/
+  functions/    auth BFF (anonymous / login / logout / refresh / visitor)
+```
 
-- Login and Registration pages
-- Main page
-- Catalog Product page
-- Detailed Product page
-- User Profile page
-- Basket page
-- About Us page
-- Sale page
+## Prerequisites
 
-### Getting Started with Create React App
+- **Node 22** (see `.nvmrc` — `nvm use`)
+- A Commercetools project + an API client (Merchant Center → Settings →
+  Developer settings; use a **Mobile & single-page application** template client)
 
-This project was bootstrapped with Create React App.
+## Setup
 
-### Available Scripts
+```bash
+nvm use            # Node 22
+npm ci
+cp .env.example .env   # then fill in the values
+```
 
-In the project directory, you can run:
+`.env` keys are documented in [`.env.example`](.env.example):
+- **Browser** (`VITE_*`) — project key + region API host. No secrets.
+- **Server-side** (`CTP_*`) — client id/secret/scopes, used only by the Netlify
+  Functions. Locally `netlify dev` injects them; in production set them in the
+  Netlify UI. **Never commit `.env`.**
 
-### npm start
+## Run locally
 
-Runs the app in the development mode.
-Open http://localhost:3000 to view it in the browser.
+```bash
+npx netlify dev        # full app incl. the auth BFF — http://localhost:8888
+# or, frontend only (auth/BFF won't work):
+npm run dev            # http://localhost:3000
+```
 
-The page will reload if you make edits.
-You will also see any lint errors in the console.
+## Scripts
 
-### npm test
+| Script              | What it does                                  |
+| ------------------- | --------------------------------------------- |
+| `npm run dev`       | Vite dev server (frontend only)               |
+| `npm run build`     | Production build → `build/` (+ SPA redirect)  |
+| `npm run preview`   | Serve the production build locally            |
+| `npm test`          | Unit tests (Vitest, single run)               |
+| `npm run test:watch`| Unit tests in watch mode                      |
+| `npm run typecheck` | `tsc --noEmit` (app + `netlify/`)             |
+| `npm run eslint`    | Lint · `npm run eslint:fix` to autofix        |
+| `npm run prettier`  | Format the repo                               |
+| `npx playwright test` | End-to-end tests                            |
 
-Launches the test runner in the interactive watch mode.
-See the section about running tests for more information.
+## Testing
 
-### npm run build
+- **Unit** — Vitest (`npm test`).
+- **E2E** — Playwright (`npx playwright test`); the config boots `netlify dev`
+  on port 8888 as the test server.
+- **Full gate** — [`./scripts/verify.sh`](scripts/verify.sh) runs install +
+  typecheck + lint + unit + e2e. CI (`.github/workflows/ci.yml`) runs the same
+  minus e2e on every PR and push to `develop`/`main`.
 
-Builds the app for production to the build folder.
-It correctly bundles React in production mode and optimizes the build for the best performance.
+## Deployment
 
-The build is minified and the filenames include the hashes.
-Your app is ready to be deployed!
+Hosted on **Netlify**. The build command is `npm run build` (publish dir
+`build/`); the auth BFF deploys alongside as Netlify Functions. Set the `CTP_*`
+environment variables in the Netlify site settings.
 
-See the section about deployment for more information.
+## Documentation
 
-### npm run eject
+- [`docs/refactor/`](docs/refactor/) — the migration plan, per-phase checklists,
+  and progress log.
+- [`docs/adr/`](docs/adr/) — architecture decision records (BFF, TanStack Query,
+  UI kit).
 
-Note: this is a one-way operation. Once you eject, you can’t go back!
+## Pages
 
-If you aren’t satisfied with the build tool and configuration choices, you can eject at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except eject will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
-
-You don’t have to ever use eject. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
-
-### npm run eslint
-
-Launches a static code analysis tool to detect problematic templates in interactive view mode.
-
-### npm run prettier
-
-Launches a code formatting tool that aims to use hard-coded rules for program layout in interactive viewing mode.
-
-### npm run prepare
-
-Runs the commit checking tool in the interactive browsing log.
-
-### npm run eslint:fix
-
-Starts the error correction tool in the interactive browsing log.
+Login · Registration · Main · Catalog · Product · Profile · Basket · About Us · Sale

--- a/docs/adr/0001-bff-for-commercetools-auth.md
+++ b/docs/adr/0001-bff-for-commercetools-auth.md
@@ -1,0 +1,30 @@
+# ADR-0001: Auth via a BFF (Netlify Functions)
+
+- **Status:** Accepted (2026, phase 2)
+- **Context**
+
+  The 2023 app used the Commercetools **client-credentials** flow directly from
+  the browser, so the `clientSecret` shipped inside the JS bundle — public to
+  anyone since 2023. Commercetools explicitly flags client credentials from a
+  browser as a vulnerability, and the SPA guidance is to keep the secret on a
+  server.
+
+- **Decision**
+
+  Introduce a thin **Backend-for-Frontend** as **Netlify Functions**
+  (`netlify/functions/auth-*`). The functions perform the token exchange
+  (anonymous / login / refresh / logout / visitor) using the `CTP_*` secrets,
+  which live only in server-side env (`netlify dev` locally, Netlify env vars in
+  prod). The browser receives tokens and talks to the CT API with
+  `@commercetools/ts-client` v4; `VITE_*` env holds only the public project key
+  and region host.
+
+- **Consequences**
+
+  - The secret is out of the browser bundle (verified by grep over the prod
+    build → 0 occurrences).
+  - A small serverless layer to maintain — but the functions are tiny
+    (token exchange only) and deploy alongside the SPA on Netlify, so no extra
+    infrastructure.
+  - Local dev requires `netlify dev` (not bare `vite`) for auth to work.
+  - Replaces the deprecated `sdk-client-v2`.

--- a/docs/adr/0002-tanstack-query-and-zustand-over-mobx.md
+++ b/docs/adr/0002-tanstack-query-and-zustand-over-mobx.md
@@ -1,0 +1,27 @@
+# ADR-0002: TanStack Query + Zustand (replacing MobX)
+
+- **Status:** Accepted (2026, phase 3)
+- **Context**
+
+  State lived in **4 MobX stores** (~1050 lines) that mixed two concerns:
+  server data (products, cart, categories — fetched, cached, refetched) and
+  genuine client state (theme, auth flag). MobX made the server-cache concern
+  verbose and hand-rolled (manual loading/error flags, no dedupe/staleness).
+
+- **Decision**
+
+  Split state by ownership:
+  - **Server state → TanStack Query 5** (`src/queries/*`): caching, request
+    dedupe, background refetch, loading/error out of the box. Catalog
+    filters/sort/page are encoded in the **URL** (shareable, back/forward
+    friendly) and drive the queries.
+  - **Client state → Zustand 5** (`src/stores/*`): only what isn't server data —
+    theme and auth state. Cart math helpers stay as pure functions.
+
+- **Consequences**
+
+  - All 4 MobX stores removed; far less boilerplate.
+  - Clear server/client boundary; catalog state is linkable via URL.
+  - Cart version-race and other fetch races fixed by Query's request handling.
+  - New dependency surface (TanStack Query) but it is the de-facto standard for
+    server state in React.

--- a/docs/adr/0003-tailwind-radix-over-mui.md
+++ b/docs/adr/0003-tailwind-radix-over-mui.md
@@ -1,0 +1,33 @@
+# ADR-0003: UI — Tailwind 4 + Radix + lucide (replacing MUI + SCSS modules)
+
+- **Status:** Accepted (2026, phase 5)
+- **Context**
+
+  The UI ran **three** parallel styling systems: SCSS modules, MUI components,
+  and MUI `sx` props. MUI + emotion added a sizeable runtime to the bundle, and
+  the SCSS modules duplicated tokens already defined as CSS variables. The two
+  candidates were "stay on MUI 7" or "Tailwind 4 + a headless primitive set".
+
+- **Decision**
+
+  Adopt **Tailwind CSS 4** (utility-first) as the single styling system, with:
+  - **Radix UI** unstyled primitives where real interaction logic is needed
+    (Slider, Dialog, Select) — wrapped in shared `baseComponents/{Button,Select,
+    Dialog}` + RHF adapters;
+  - **lucide-react** for icons;
+  - design tokens as CSS variables in a single `src/styles/tailwind.css`.
+
+  The migration was an **engine swap that kept the look 1:1**, verified visually
+  per component group. Tailwind **preflight is intentionally not enabled** — the
+  app relied on browser defaults + a normalize block, so enabling preflight would
+  have reset headings/lists/links app-wide (not 1:1); the normalize block is kept
+  and minimal `a`/`button` resets reproduce the bits MUI's CssBaseline provided.
+
+- **Consequences**
+
+  - One styling system in the tree: **0 `.scss` files**; `sass` and `classnames`
+    removed; MUI + emotion uninstalled (smaller bundle, no emotion runtime).
+  - `*Mobile` component forks collapsed into adaptive components.
+  - Trade-off: more utility classes in markup, and a non-standard "preflight off"
+    setup that future contributors must be aware of (documented in
+    `tailwind.css`).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,11 @@
+# Architecture Decision Records
+
+Short records of the key decisions taken during the 2026 refactor. Format:
+context → decision → consequences. Full rationale and alternatives live in
+[`../../REFACTORING_PLAN.md`](../../REFACTORING_PLAN.md).
+
+| ADR | Decision |
+| --- | --- |
+| [0001](0001-bff-for-commercetools-auth.md) | Auth via a BFF (Netlify Functions) — keep the Commercetools secret server-side |
+| [0002](0002-tanstack-query-and-zustand-over-mobx.md) | Server state → TanStack Query; minimal client state → Zustand (replacing MobX) |
+| [0003](0003-tailwind-radix-over-mui.md) | UI: Tailwind 4 + Radix + lucide (replacing MUI + SCSS modules) |

--- a/docs/refactor/phase-6.md
+++ b/docs/refactor/phase-6.md
@@ -18,8 +18,10 @@ Plan reference: REFACTORING_PLAN.md §5, "Фаза 6".
         focus-return-to-trigger still TODO here.
   - [x] `ThemeToggle.tsx`: `aria-label="Toggle theme"` — done early (PR #222)
   - [x] `ErrorBoundary.tsx`: uses `RoutePaths.MAIN` — done early (PR #222)
-- [ ] **6.5** Docs: rewrite README (stack, setup, scripts), ADRs for key
-      decisions (BFF, TanStack Query, UI kit choice).
+- [x] **6.5** Docs (2026-06-18): README rewritten (real stack/architecture/setup/
+      scripts/structure; dropped the stale CRA/MUI/MobX boilerplate). ADRs added in
+      `docs/adr/`: 0001 BFF auth, 0002 TanStack Query + Zustand, 0003 Tailwind +
+      Radix + lucide.
 - [~] **6.6** Dependency security (2026-06-18): `npm audit` went from
       **1 critical + 14 moderate + 5 low → 9 low** (all one dev-only advisory).
   - [x] **critical** `swiper` (runtime, HeroCarousel/ProductCarousel): bumped


### PR DESCRIPTION
Phase 6 item **6.5** (documentation).

- **README** fully rewritten: dropped the stale CRA/MUI/MobX/Formik/Sass/Jest boilerplate; documents the real stack (Vite 7 · React 19 · TS 5.9 · TanStack Query 5 · Zustand 5 · RHF+zod 4 · @commercetools/ts-client v4 + Netlify-Functions BFF · Tailwind 4 + Radix + lucide · Vitest + Playwright), plus an architecture note (BFF keeps the CT secret server-side), prerequisites (Node 22), `.env` setup, accurate npm scripts, project structure, testing, and deployment.
- **ADRs** added in `docs/adr/`:
  - 0001 — BFF (Netlify Functions) for Commercetools auth
  - 0002 — TanStack Query + Zustand over MobX
  - 0003 — Tailwind 4 + Radix + lucide over MUI + SCSS modules

Docs only — no code changes.