### PR TITLE
feat(phase-6.4): focus-trap + focus-return in the mobile filter drawer

### DIFF
--- a/docs/refactor/phase-6.md
+++ b/docs/refactor/phase-6.md
@@ -11,13 +11,15 @@ Plan reference: REFACTORING_PLAN.md §5, "Фаза 6".
       (target: 80%).
 - [ ] **6.3** Playwright in CI against Netlify preview deploys; refresh
       phase 0 scenarios to the final UI.
-- [ ] **6.4** A11y pass: form labels/aria, modal focus management, dark theme
-      contrast. Specific items from the PR #221 review (phase 5 part 1):
-  - [~] Filter mobile drawer (`Filter.tsx`): Esc-to-close + focus-to-close-button
-        + `role="dialog"`/`aria-modal` DONE (PR #222); full focus-TRAP and
-        focus-return-to-trigger still TODO here.
+- [~] **6.4** A11y pass. Specific items from the PR #221 review (phase 5 part 1):
+  - [x] Filter mobile drawer (`Filter.tsx`): Esc-to-close + focus-to-close-button
+        + `role="dialog"`/`aria-modal` (PR #222), and now **full focus-TRAP**
+        (Tab/Shift+Tab wrap inside) + **focus-return-to-trigger** on close
+        (2026-06-18) — verified live: 21 focusables trapped, focus returns to the
+        filter trigger.
   - [x] `ThemeToggle.tsx`: `aria-label="Toggle theme"` — done early (PR #222)
   - [x] `ErrorBoundary.tsx`: uses `RoutePaths.MAIN` — done early (PR #222)
+  - [ ] Remaining: broad form labels/aria audit + dark-theme contrast pass.
 - [x] **6.5** Docs (2026-06-18): README rewritten (real stack/architecture/setup/
       scripts/structure; dropped the stale CRA/MUI/MobX boilerplate). ADRs added in
       `docs/adr/`: 0001 BFF auth, 0002 TanStack Query + Zustand, 0003 Tailwind +

--- a/src/components/Filter/Filter.tsx
+++ b/src/components/Filter/Filter.tsx
@@ -47,19 +47,44 @@ const FilterControls: React.FC<FilterControlsProps & { mobile?: boolean }> = ({
   </>
 );
 
+const FOCUSABLE =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
 const Filter: React.FC<Props> = ({ className, ...controls }) => {
   const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
   const closeRef = useRef<HTMLButtonElement>(null);
 
-  // a11y: Esc closes the drawer; focus moves to the close button on open
+  // a11y (drawer): Esc closes; focus moves to the close button on open, is
+  // trapped inside while open, and returns to the trigger on close.
   useEffect(() => {
     if (!open) return undefined;
+    const trigger = triggerRef.current;
     closeRef.current?.focus();
     const onKey = (e: KeyboardEvent): void => {
-      if (e.key === 'Escape') setOpen(false);
+      if (e.key === 'Escape') {
+        setOpen(false);
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      const items = panelRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE);
+      if (!items || items.length === 0) return;
+      const first = items[0];
+      const last = items[items.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
     };
     document.addEventListener('keydown', onKey);
-    return (): void => document.removeEventListener('keydown', onKey);
+    return (): void => {
+      document.removeEventListener('keydown', onKey);
+      trigger?.focus();
+    };
   }, [open]);
 
   return (
@@ -70,7 +95,13 @@ const Filter: React.FC<Props> = ({ className, ...controls }) => {
       </aside>
 
       {/* mobile trigger */}
-      <button type="button" aria-label="filter" onClick={(): void => setOpen(true)} className="md:hidden">
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-label="filter"
+        onClick={(): void => setOpen(true)}
+        className="md:hidden"
+      >
         <ListFilter />
       </button>
 
@@ -78,7 +109,10 @@ const Filter: React.FC<Props> = ({ className, ...controls }) => {
       {open && (
         <div className="fixed inset-0 z-[1000] md:hidden" role="dialog" aria-modal="true" aria-label="Filters">
           <div className="absolute inset-0 bg-black/40" onClick={(): void => setOpen(false)} aria-hidden />
-          <div className="absolute inset-y-0 left-0 w-[85vw] max-w-sm overflow-y-auto bg-page p-4 shadow-xl">
+          <div
+            ref={panelRef}
+            className="absolute inset-y-0 left-0 w-[85vw] max-w-sm overflow-y-auto bg-page p-4 shadow-xl"
+          >
             <button
               ref={closeRef}
               type="button"


### PR DESCRIPTION
Phase 6 item **6.4** (a11y) — the focus-management TODO from the PR #221 review.

The mobile filter drawer already had Esc-to-close, focus-to-close-button, and `role=dialog`/`aria-modal` (PR #222). This adds:
- **Focus trap** — Tab from the last focusable wraps to the first, Shift+Tab from the first wraps to the last; keyboard focus stays inside the open drawer.
- **Focus return** — closing (Esc / overlay click / close button) restores focus to the filter trigger.

No new deps; standard pattern (querying focusables in the panel + wrapping at the boundaries; cleanup returns focus to the captured trigger).

**Verified live** (mobile 375): focus → Close on open; 21 focusables trapped both directions; focus returns to the `filter` trigger on close. typecheck + eslint(0 errors) + 41 unit green.

Remaining in 6.4 (separate pass): broad form label/aria audit + dark-theme contrast.