### PR TITLE
ci(phase-6.3): add Playwright e2e job (guarded, opt-in)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,38 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  # E2E against the full app (Vite + auth BFF) booted by `netlify dev`, hitting
+  # the real Commercetools project. Dormant until configured — to enable, in the
+  # repo settings add:
+  #   • Variables:  RUN_E2E=true, VITE_PROJECT_KEY_CLIENT, VITE_API_URL_CLIENT
+  #   • Secrets:    CTP_PROJECT_KEY, CTP_CLIENT_ID, CTP_CLIENT_SECRET,
+  #                 CTP_AUTH_URL, CTP_SCOPES
+  # (use a minimal-scope "SPA" CT client). See docs/refactor/phase-6.md §6.3.
+  e2e:
+    if: ${{ vars.RUN_E2E == 'true' && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: E2E (Playwright)
+        run: npx playwright test
+        env:
+          VITE_PROJECT_KEY_CLIENT: ${{ vars.VITE_PROJECT_KEY_CLIENT }}
+          VITE_API_URL_CLIENT: ${{ vars.VITE_API_URL_CLIENT }}
+          CTP_PROJECT_KEY: ${{ secrets.CTP_PROJECT_KEY }}
+          CTP_CLIENT_ID: ${{ secrets.CTP_CLIENT_ID }}
+          CTP_CLIENT_SECRET: ${{ secrets.CTP_CLIENT_SECRET }}
+          CTP_AUTH_URL: ${{ secrets.CTP_AUTH_URL }}
+          CTP_SCOPES: ${{ secrets.CTP_SCOPES }}

--- a/docs/refactor/phase-6.md
+++ b/docs/refactor/phase-6.md
@@ -9,8 +9,22 @@ Plan reference: REFACTORING_PLAN.md §5, "Фаза 6".
       (catalog+filters, cart flows, auth flow).
 - [ ] **6.2** Vitest coverage thresholds for `entities/*` and `shared/api`
       (target: 80%).
-- [ ] **6.3** Playwright in CI against Netlify preview deploys; refresh
-      phase 0 scenarios to the final UI.
+- [~] **6.3** Playwright in CI (2026-06-18). Added an `e2e` job to `ci.yml` that
+      boots the full app (`netlify dev` → Vite + auth BFF) and runs Playwright
+      against the real Commercetools project. **Dormant until configured** (guarded
+      by `vars.RUN_E2E`), so it never reds a PR before the env exists. One-time
+      repo setup (Settings → Secrets and variables → Actions):
+  - **Variables:** `RUN_E2E=true`, `VITE_PROJECT_KEY_CLIENT`, `VITE_API_URL_CLIENT`
+  - **Secrets:** `CTP_PROJECT_KEY`, `CTP_CLIENT_ID`, `CTP_CLIENT_SECRET`,
+    `CTP_AUTH_URL`, `CTP_SCOPES` (use the minimal-scope SPA client)
+
+      Chose this (run in CI) over the "against a Netlify preview deploy" variant
+      because `deployment_status`-triggered workflows only run from the **default
+      branch**; with `develop` as the working branch (merged to `main` only at the
+      end), the preview approach would stay dormant during phase-6 dev. Note: the
+      registration scenario creates a real customer in CT on each run (unique
+      email) — inherent to e2e-against-real-CT. Phase 0 scenarios already track the
+      final UI (kept green throughout phase 5).
 - [~] **6.4** A11y pass. Specific items from the PR #221 review (phase 5 part 1):
   - [x] Filter mobile drawer (`Filter.tsx`): Esc-to-close + focus-to-close-button
         + `role="dialog"`/`aria-modal` (PR #222), and now **full focus-TRAP**


### PR DESCRIPTION
Phase 6 item **6.3** (Playwright in CI).

Adds an `e2e` job to `ci.yml` that boots the full app (`netlify dev` → Vite + auth BFF) and runs Playwright against the real Commercetools project.

**Non-breaking / opt-in:** the job is guarded by `vars.RUN_E2E == 'true'` (+ pull_request), so until the env is configured it is **skipped** and CI stays green. To activate, add in repo Settings → Secrets and variables → Actions:
- **Variables:** `RUN_E2E=true`, `VITE_PROJECT_KEY_CLIENT`, `VITE_API_URL_CLIENT`
- **Secrets:** `CTP_PROJECT_KEY`, `CTP_CLIENT_ID`, `CTP_CLIENT_SECRET`, `CTP_AUTH_URL`, `CTP_SCOPES` (minimal-scope SPA client)

**Why this over "against a Netlify preview deploy":** `deployment_status` workflows only run from the **default branch**. With `develop` as the working branch (merged to `main` only at the end), the preview approach would stay dormant during phase-6 development; running e2e in CI works on `develop` PRs now. `playwright.config.ts` already self-hosts `netlify dev` in CI (`reuseExistingServer: false`), so no config change was needed.

Note: the registration scenario creates a real CT customer per run (unique email) — inherent to e2e-against-real-CT.

This PR's own CI: `verify` runs as before; `e2e` is skipped (RUN_E2E unset).