### PR TITLE
ci: enable e2e-against-Netlify-preview workflow on default branch

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,41 @@
+name: E2E
+
+# Runs Playwright against the Netlify deploy that just went live, using its URL —
+# no Commercetools env/secrets in GitHub (the preview already has them on Netlify).
+#
+# NOTE: `deployment_status`-triggered workflows only run when this file is on the
+# repository's DEFAULT branch (`main`). Netlify is configured with Production =
+# `main`, Branch deploys = `develop`, and Deploy Previews for PRs — so PRs into
+# `develop` and pushes to `develop`/`main` all emit a `deployment_status` this
+# reacts to. Until this file is on `main` it stays dormant (develop PRs are still
+# covered locally + by the CI `verify` job).
+on:
+  deployment_status:
+
+jobs:
+  e2e:
+    # only after a Netlify deploy succeeds; target_url is that deploy's URL
+    if: ${{ github.event.deployment_status.state == 'success' && github.event.deployment_status.target_url != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      # check out the exact commit that was deployed (carries the matching
+      # playwright.config); for deployment_status the SHA is on the deployment.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.deployment.sha }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: E2E (Playwright) against the deployed URL
+        run: npx playwright test
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ github.event.deployment_status.target_url }}


### PR DESCRIPTION
Adds **only** `.github/workflows/e2e.yml` to `main`.

`deployment_status`-triggered workflows fire **only when the file is on the default branch** (`main`). With Netlify configured (Production=main, Branch deploys=develop, Deploy Previews for PRs), every develop PR preview / branch deploy / production deploy emits a `deployment_status` — this workflow reacts and runs Playwright against that deploy's URL. No Commercetools secrets in GitHub (the deploy already has the env on Netlify).

The job checks out the **deployed commit** (`github.event.deployment.sha`), so it uses that commit's `playwright.config.ts` + tests — no other phase-6 code is brought to `main` by this PR (full code lands at the final develop→main merge).

Companion PR #231 (into `develop`) carries the matching `playwright.config.ts` + the same workflow + removes the old env-based job.