### PR TITLE
test(phase-6.1): MSW 2 mocks + integration tests (catalog, cart, auth)

### DIFF
--- a/docs/refactor/PROGRESS.md
+++ b/docs/refactor/PROGRESS.md
@@ -7,10 +7,10 @@
 
 - **Phase:** 6 — **quality consolidation, in progress.** Merged to `develop`:
   **6.3** (Playwright in CI vs Netlify preview), **6.4** Filter focus-trap,
-  **6.5** README + ADRs, **6.6** dependency security. Pending: **6.1** MSW
-  integration tests, **6.2** coverage thresholds, **6.4** remainder (form aria +
-  contrast). Phase 5 (UI) **COMPLETE** — Tailwind 4 + Radix, engine-swap keeping
-  the look 1:1, all parts merged.
+  **6.5** README + ADRs, **6.6** dependency security. **6.1** MSW integration
+  tests done (PR open). Pending: **6.2** coverage thresholds, **6.4** remainder
+  (form aria + contrast). Phase 5 (UI) **COMPLETE** — Tailwind 4 + Radix,
+  engine-swap keeping the look 1:1, all parts merged.
   - **Part 1 MERGED** to `develop` (PR #221) + a11y nits (PR #222): foundation,
     Footer, Header (forks merged), Card+ProductList, adaptive Filter (Filter/
     FilterMobile + Sorting/SortMobile forks gone), Catalog shell, Cart page
@@ -87,6 +87,31 @@
 | 2026-06-15 | Icons → **lucide-react**; interactive primitives → **hybrid Radix** (Slider/Dialog/Select) + native (checkbox/pagination/toast). Brand GitHub icon inlined (lucide dropped brand marks) |
 
 ## Session log
+
+### 2026-06-19 — Session 11 (phase 6.1 — MSW 2 + integration tests)
+
+- added **MSW 2** (`msw@^2`) + a shared harness in `src/test/`: `server.ts`
+  (setupServer + `recordRequests` helper), `handlers.ts` (BFF `/api/auth/*` +
+  CT endpoints), `fixtures.ts` (minimal CT payloads shaped to the transforms),
+  `utils.tsx` (per-test QueryClient wrapper, retries off).
+- wired MSW into `setupTests.ts` with **`server.listen()` at setup-file eval
+  time** (not in `beforeAll`) — the CT SDK captures `httpClient: fetch` once at
+  module load, so MSW must patch `globalThis.fetch` before `ctClient` imports.
+  `onUnhandledRequest: 'error'`; `afterEach` resets handlers + event listeners.
+- `vite.config` `test.env` pins a non-secret CT host/projectKey so handler URLs
+  match the SDK in CI (no `.env` there).
+- **29 integration tests** (all green): catalog+filters (subtree/attribute/price/
+  sort/search/pagination query-arg construction + `select` transforms, service +
+  hook level), cart (active-cart 200/404→null/throw, create/update/delete,
+  mutation cache writes), auth (visitor memo, lazy anon, refresh/expiry/drop,
+  login + signup request shaping). Total unit+integration **70/70**.
+- landmine found: the CT SDK reads `errors[0].code` on an error body — an empty
+  `errors: []` throws and is reported as a network error (`statusCode 0`); mocks
+  for error responses must include a populated `errors[]`.
+- **Gate:** typecheck clean · eslint 0 errors (17 pre-existing warnings) · 70
+  unit/integration · 11 e2e (Node 22, vs local `netlify dev`).
+- **Next:** 6.2 (coverage thresholds for `services/*` + `queries/*`, ~80%),
+  6.4 remainder (form aria + contrast), close.
 
 ### 2026-06-19 — Session 10 (phase 6.3 e2e merged; route scroll-restoration fix)
 

--- a/docs/refactor/phase-6.md
+++ b/docs/refactor/phase-6.md
@@ -5,8 +5,19 @@ Plan reference: REFACTORING_PLAN.md §5, "Фаза 6".
 
 ## Checklist
 
-- [ ] **6.1** MSW 2 mocks for CT API; integration tests for features
-      (catalog+filters, cart flows, auth flow).
+- [x] **6.1** MSW 2 mocks for CT API; integration tests for features (2026-06-19).
+      Shared harness in `src/test/` (`server.ts` + `handlers.ts` + `fixtures.ts` +
+      `utils.tsx`); MSW intercepts the BFF (`/api/auth/*`) **and** the CT SDK's
+      `fetch` — `server.listen()` runs at setup-file eval so it patches
+      `globalThis.fetch` before `ctClient` captures it; `vite.config` `test.env`
+      pins a deterministic CT host so handler URLs match the SDK in CI. **29 new
+      tests** across catalog+filters (request query-arg construction: subtree
+      filter, attribute filters, price cents, sort mapping, search `text.en`,
+      pagination offset + `select` transforms), cart flows (active-cart
+      200/404→null/throw, create/update/delete, mutation cache writes), and auth
+      (visitor memo, lazy anon, refresh/expiry, login/signup request shaping).
+      Note: CT error responses must carry a populated `errors[]` — the SDK reads
+      `errors[0].code` and an empty array drops it into the network-error path.
 - [ ] **6.2** Vitest coverage thresholds for `entities/*` and `shared/api`
       (target: 80%).
 - [~] **6.3** Playwright in CI (2026-06-18). Runs e2e **against the Netlify deploy

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "husky": "^8.0.3",
         "jsdom": "^29.1.1",
         "lint-staged": "^13.2.3",
+        "msw": "^2.14.6",
         "netlify-cli": "^26.1.0",
         "prettier": "^3.8.4",
         "tailwind-merge": "^3.6.0",
@@ -2203,6 +2204,98 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
+      "integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
+      "integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@inquirer/external-editor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
@@ -2215,6 +2308,34 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
+      "integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+      "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2424,6 +2545,31 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.9",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.9.tgz",
+      "integrity": "sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mswjs/interceptors/node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@netlify/ai": {
       "version": "0.4.1",
@@ -6217,6 +6363,31 @@
         "@octokit/openapi-types": "^27.0.0"
       }
     },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-3.0.0.tgz",
+      "integrity": "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
@@ -8455,6 +8626,23 @@
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
       "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/set-cookie-parser": {
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz",
+      "integrity": "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
       "license": "MIT"
     },
@@ -13216,6 +13404,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
     "node_modules/fast-stringify": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fast-stringify/-/fast-stringify-4.0.0.tgz",
@@ -13239,6 +13444,16 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
@@ -14160,6 +14375,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/graphql": {
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/h3": {
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
@@ -14271,6 +14496,24 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-5.0.1.tgz",
+      "integrity": "sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/set-cookie-parser": "^2.4.10",
+        "set-cookie-parser": "^3.0.1"
+      }
+    },
+    "node_modules/headers-polyfill/node_modules/set-cookie-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
+      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
@@ -15355,6 +15598,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-npm": {
       "version": "6.1.0",
@@ -17337,6 +17587,74 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/msw": {
+      "version": "2.14.6",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.14.6.tgz",
+      "integrity": "sha512-ALe+N10S72cyx94cMcy3Zs4HhXCj35sgeAL4c+WTvKi0zWnbd8/h0lcFqv0mb2P+aSgAdD7p9HzvA0DiUPxsyg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/confirm": "^6.0.11",
+        "@mswjs/interceptors": "^0.41.3",
+        "@open-draft/deferred-promise": "^3.0.0",
+        "@types/statuses": "^2.0.6",
+        "cookie": "^1.1.1",
+        "graphql": "^16.13.2",
+        "headers-polyfill": "^5.0.1",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.11.11",
+        "statuses": "^2.0.2",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.1",
+        "type-fest": "^5.5.0",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/msw/node_modules/type-fest": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/multiparty": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-4.3.0.tgz",
@@ -18610,6 +18928,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/own-keys": {
       "version": "1.0.1",
@@ -20484,6 +20809,13 @@
         "node": ">= 4"
       }
     },
+    "node_modules/rettime": {
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.11.tgz",
+      "integrity": "sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -21364,6 +21696,13 @@
         "fast-fifo": "^1.3.2",
         "text-decoder": "^1.1.0"
       }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -22726,6 +23065,16 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
       }
     },
     "node_modules/untildify": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "husky": "^8.0.3",
     "jsdom": "^29.1.1",
     "lint-staged": "^13.2.3",
+    "msw": "^2.14.6",
     "netlify-cli": "^26.1.0",
     "prettier": "^3.8.4",
     "tailwind-merge": "^3.6.0",

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,6 +1,23 @@
 // jest-dom adds custom matchers for asserting on DOM nodes (vitest build).
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom/vitest';
+import { afterAll, afterEach } from 'vitest';
+
+import { server } from './test/server';
+
+// Start MSW at setup-file eval time — BEFORE any test module imports ctClient,
+// which captures `httpClient: fetch` once at module load. Listening here patches
+// globalThis.fetch first, so the SDK's captured reference is the intercepted one.
+// (Putting listen() in beforeAll would be too late: the service modules import
+// during test-file evaluation, which runs after setup but before beforeAll.)
+server.listen({ onUnhandledRequest: 'error' });
+
+afterEach(() => {
+  server.resetHandlers();
+  server.events.removeAllListeners();
+});
+
+afterAll(() => server.close());
 
 window.matchMedia = vi.fn().mockImplementation((query) => {
   return {

--- a/src/test/auth.integration.test.ts
+++ b/src/test/auth.integration.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
+
+import {
+  clearSession,
+  ensureSessionToken,
+  getSessionToken,
+  getVisitorToken,
+  hasSession,
+  isCustomerSession,
+  loginSession,
+} from '../services/session';
+import { customerLogin, customerSignUp } from '../services/authService';
+import { server, recordRequests } from './server';
+
+const SESSION_KEY = 'ct_session';
+const writeStoredSession = (kind: 'anonymous' | 'customer', expiresInMs: number): void =>
+  localStorage.setItem(SESSION_KEY, JSON.stringify({ token: 'stored', expiresAt: Date.now() + expiresInMs, kind }));
+
+const authCalls = (calls: Request[], path: string): Request[] =>
+  calls.filter((c) => c.url.endsWith(`/api/auth/${path}`));
+
+beforeEach(() => localStorage.clear());
+
+describe('session token lifecycle (auth BFF via MSW)', () => {
+  it('memoizes the visitor token — one BFF call for repeated reads', async () => {
+    clearSession(); // reset in-memory visitor cache
+    const calls = recordRequests();
+
+    const a = await getVisitorToken();
+    const b = await getVisitorToken();
+
+    expect(a).toBe('visitor-token');
+    expect(b).toBe('visitor-token');
+    expect(authCalls(calls, 'visitor')).toHaveLength(1);
+  });
+
+  it('creates an anonymous session lazily and reuses it', async () => {
+    const calls = recordRequests();
+
+    const first = await ensureSessionToken();
+    expect(first).toBe('anon-token');
+    expect(hasSession()).toBe(true);
+    expect(isCustomerSession()).toBe(false);
+    expect(localStorage.getItem(SESSION_KEY)).toContain('anonymous');
+
+    const second = await ensureSessionToken();
+    expect(second).toBe('anon-token');
+    expect(authCalls(calls, 'anonymous')).toHaveLength(1); // not re-created
+  });
+
+  it('throws when reading a session token without any session', async () => {
+    await expect(getSessionToken()).rejects.toThrow(/no active session/i);
+  });
+
+  it('refreshes a stale token through the BFF cookie and rewrites storage', async () => {
+    writeStoredSession('customer', 10_000); // within the 60s expiry slack → stale
+    const calls = recordRequests();
+
+    const token = await getSessionToken();
+
+    expect(token).toBe('refreshed-token');
+    expect(authCalls(calls, 'refresh')).toHaveLength(1);
+    expect(localStorage.getItem(SESSION_KEY)).toContain('refreshed-token');
+    expect(isCustomerSession()).toBe(true); // kind preserved across refresh
+  });
+
+  it('drops the session when refresh fails', async () => {
+    writeStoredSession('anonymous', 10_000);
+    server.use(http.post('/api/auth/refresh', () => new HttpResponse(null, { status: 401 })));
+
+    await expect(getSessionToken()).rejects.toBeDefined();
+    expect(localStorage.getItem(SESSION_KEY)).toBeNull();
+  });
+
+  it('login stores a customer session via the BFF', async () => {
+    const calls = recordRequests();
+    await loginSession('shopper@test.dev', 'Secret123');
+
+    const loginCall = authCalls(calls, 'login')[0];
+    expect(await loginCall!.clone().json()).toEqual({ email: 'shopper@test.dev', password: 'Secret123' });
+    expect(isCustomerSession()).toBe(true);
+  });
+});
+
+describe('authService (BFF + CT me-endpoints via MSW)', () => {
+  it('logs in: BFF login, me/login with credentials, then fetches the customer', async () => {
+    const calls = recordRequests();
+    const response = await customerLogin('shopper@test.dev', 'Secret123');
+
+    expect(response.statusCode).toBe(200);
+    expect(authCalls(calls, 'login').length).toBeGreaterThanOrEqual(1);
+
+    const meLogin = calls.find((c) => c.method === 'POST' && c.url.endsWith('/me/login'));
+    expect(await meLogin!.clone().json()).toEqual({ email: 'shopper@test.dev', password: 'Secret123' });
+    expect(calls.some((c) => c.method === 'GET' && c.url.endsWith('/me'))).toBe(true);
+  });
+
+  it('signs up: anonymous session, then me/signup with a shaped customer draft', async () => {
+    const calls = recordRequests();
+    const response = await customerSignUp({
+      email: 'new@test.dev',
+      password: 'Secret123',
+      firstName: 'New',
+      lastName: 'Shopper',
+      date: '1990-01-01',
+      countryShipping: 'DE',
+      streetShipping: 'Main 1',
+      postalCodeShipping: '10115',
+      cityShipping: 'Berlin',
+      checkedShippingDefault: true,
+      checkedAddBillingForm: false,
+      countryBilling: 'DE',
+      streetBilling: 'Side 2',
+      postalCodeBilling: '10117',
+      cityBilling: 'Berlin',
+      checkedBillingDefault: false,
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(authCalls(calls, 'anonymous')).toHaveLength(1);
+
+    const signup = calls.find((c) => c.method === 'POST' && c.url.endsWith('/me/signup'));
+    const body = (await signup!.clone().json()) as {
+      email: string;
+      addresses: unknown[];
+      defaultShippingAddress?: number;
+      defaultBillingAddress?: number;
+    };
+    expect(body.email).toBe('new@test.dev');
+    expect(body.addresses).toHaveLength(2);
+    expect(body.defaultShippingAddress).toBe(0);
+    expect(body.defaultBillingAddress).toBeUndefined();
+    // after a 201, the service logs the customer in and fetches /me
+    expect(calls.some((c) => c.method === 'GET' && c.url.endsWith('/me'))).toBe(true);
+  });
+});

--- a/src/test/cart.integration.test.tsx
+++ b/src/test/cart.integration.test.tsx
@@ -1,0 +1,133 @@
+import type { ReactElement, ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+
+import { createCart, deleteCart, getActiveCart, updateCart } from '../services/cartService';
+import { cartKey, useAddToCartMutation, useApplyPromoMutation, useClearCartMutation } from '../queries/cart';
+import { CT } from './handlers';
+import { server, recordRequests } from './server';
+import { createTestQueryClient } from './utils';
+import { cartWithItem } from './fixtures';
+
+const SESSION_KEY = 'ct_session';
+const seedSession = (kind: 'anonymous' | 'customer' = 'anonymous'): void =>
+  localStorage.setItem(SESSION_KEY, JSON.stringify({ token: 'seeded', expiresAt: Date.now() + 3_600_000, kind }));
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+describe('cart service (CT API via MSW)', () => {
+  it('reads the active cart for a session', async () => {
+    seedSession();
+    const cart = await getActiveCart();
+    expect(cart?.id).toBe('cart-1');
+  });
+
+  it('returns null when the session has no active cart (404)', async () => {
+    seedSession();
+    server.use(
+      http.get(`${CT}/me/active-cart`, () =>
+        HttpResponse.json(
+          { statusCode: 404, message: 'No active cart found.', errors: [{ code: 'ResourceNotFound', message: 'x' }] },
+          { status: 404 }
+        )
+      )
+    );
+    await expect(getActiveCart()).resolves.toBeNull();
+  });
+
+  it('rethrows non-404 errors from active-cart', async () => {
+    seedSession();
+    server.use(
+      http.get(`${CT}/me/active-cart`, () =>
+        HttpResponse.json(
+          { statusCode: 500, message: 'Server error', errors: [{ code: 'General', message: 'boom' }] },
+          { status: 500 }
+        )
+      )
+    );
+    await expect(getActiveCart()).rejects.toBeDefined();
+  });
+
+  it('creates an anonymous session on the BFF when none exists, then creates a cart in EUR', async () => {
+    const calls = recordRequests();
+    const cart = await createCart();
+
+    expect(cart.id).toBe('cart-1');
+    expect(calls.some((c) => c.url.endsWith('/api/auth/anonymous'))).toBe(true);
+    const createCall = calls.find((c) => c.method === 'POST' && c.url.endsWith('/me/carts'));
+    expect(await createCall!.clone().json()).toEqual({ currency: 'EUR' });
+    expect(localStorage.getItem(SESSION_KEY)).toContain('anonymous');
+  });
+
+  it('sends version + actions on update', async () => {
+    seedSession();
+    const calls = recordRequests();
+    await updateCart(cartWithItem as never, [{ action: 'addLineItem', productId: 'prod-red-tee', quantity: 1 }]);
+
+    const updateCall = calls.find((c) => c.method === 'POST' && /\/me\/carts\/cart-1$/.test(new URL(c.url).pathname));
+    expect(updateCall).toBeDefined();
+    expect(await updateCall!.clone().json()).toEqual({
+      version: 2,
+      actions: [{ action: 'addLineItem', productId: 'prod-red-tee', quantity: 1 }],
+    });
+  });
+
+  it('passes the cart version as a query arg on delete', async () => {
+    seedSession();
+    const calls = recordRequests();
+    await deleteCart(cartWithItem as never);
+
+    const deleteCall = calls.find((c) => c.method === 'DELETE');
+    expect(new URL(deleteCall!.url).searchParams.get('version')).toBe('2');
+  });
+});
+
+describe('cart mutations (TanStack Query cache)', () => {
+  const renderWithClient = <T,>(hook: () => T) => {
+    const queryClient = createTestQueryClient();
+    function Wrapper({ children }: { children: ReactNode }): ReactElement {
+      return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+    }
+    return { queryClient, ...renderHook(hook, { wrapper: Wrapper }) };
+  };
+
+  it('add-to-cart creates a cart then writes the server cart into the cache', async () => {
+    const { queryClient, result } = renderWithClient(() => useAddToCartMutation());
+
+    await result.current.mutateAsync({ productId: 'prod-red-tee', quantity: 2 });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(queryClient.getQueryData(cartKey)).toMatchObject({ id: 'cart-1', version: 2 });
+  });
+
+  it('clear-cart deletes the cached cart and resets the cache to null', async () => {
+    seedSession();
+    const { queryClient, result } = renderWithClient(() => useClearCartMutation());
+    queryClient.setQueryData(cartKey, cartWithItem);
+
+    const calls = recordRequests();
+    await result.current.mutateAsync(undefined);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(calls.some((c) => c.method === 'DELETE')).toBe(true);
+    expect(queryClient.getQueryData(cartKey)).toBeNull();
+  });
+
+  it('apply-promo sends an addDiscountCode action against the cached cart', async () => {
+    const { queryClient, result } = renderWithClient(() => useApplyPromoMutation());
+    queryClient.setQueryData(cartKey, cartWithItem);
+
+    server.use(http.post(`${CT}/me/carts/:id`, () => HttpResponse.json({ ...cartWithItem, version: 3 })));
+    const calls = recordRequests();
+    await result.current.mutateAsync('BAGS15-SP');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const updateCall = calls.find((c) => c.method === 'POST' && /\/me\/carts\/cart-1$/.test(new URL(c.url).pathname));
+    const body = (await updateCall!.clone().json()) as { actions: { action: string; code?: string }[] };
+    expect(body.actions[0]).toEqual({ action: 'addDiscountCode', code: 'BAGS15-SP' });
+    expect(queryClient.getQueryData(cartKey)).toMatchObject({ version: 3 });
+  });
+});

--- a/src/test/catalog-hooks.integration.test.tsx
+++ b/src/test/catalog-hooks.integration.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { useCategoriesQuery } from '../queries/categories';
+import { useCatalogProductsQuery, useCategoryAttributesQuery } from '../queries/products';
+import type { CatalogParams } from '../queries/catalogParams';
+import { SortOption } from '../components/baseComponents/SortingList/SortList.enum';
+import { recordRequests } from './server';
+import { createWrapper } from './utils';
+
+const attributes = { colorAttribute: 'color', sizeAttribute: 'size-clothes' };
+
+const params = (overrides: Partial<CatalogParams> = {}): CatalogParams => ({
+  page: 1,
+  sort: SortOption.Default,
+  search: '',
+  sizes: [],
+  colors: [],
+  price: [1, 50],
+  ...overrides,
+});
+
+const lastSearchFilters = (calls: Request[]): string[] => {
+  const call = [...calls].reverse().find((c) => c.url.includes('/product-projections/search'));
+  return call ? new URL(call.url).searchParams.getAll('filter') : [];
+};
+
+describe('catalog query hooks (TanStack Query + MSW)', () => {
+  it('useCategoriesQuery nests subcategories under sorted main categories', async () => {
+    const { result } = renderHook(() => useCategoriesQuery(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const cats = result.current.data!;
+    expect(cats.map((c) => c.name.en)).toEqual(['Clothes', 'Bags']); // sorted by orderHint
+    expect(cats[0]!.subcategories?.map((s) => s.name.en)).toEqual(['T-Shirts']);
+  });
+
+  it('useCategoryAttributesQuery resolves the color/size attribute names for a category', async () => {
+    const { result } = renderHook(() => useCategoryAttributesQuery('clothes'), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ colorAttribute: 'color', sizeAttribute: 'size-clothes' });
+  });
+
+  it('plain browse → category subtree only, transformed into products', async () => {
+    const calls = recordRequests();
+    const { result } = renderHook(() => useCatalogProductsQuery('cat-clothes', params(), attributes), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.total).toBe(2);
+    expect(result.current.data?.products.map((p) => p.productName)).toEqual(['Red Tee', 'Blue Tee']);
+
+    const filters = lastSearchFilters(calls);
+    expect(filters).toEqual(['categories.id:subtree("cat-clothes")']);
+  });
+
+  it('search term routes to a text.en search', async () => {
+    const calls = recordRequests();
+    const { result } = renderHook(() => useCatalogProductsQuery('cat-clothes', params({ search: 'tee' }), attributes), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const call = [...calls].reverse().find((c) => c.url.includes('/product-projections/search'));
+    expect(new URL(call!.url).searchParams.get('text.en')).toBe('tee');
+  });
+
+  it('active size filter routes to an attribute-filtered search', async () => {
+    const calls = recordRequests();
+    const { result } = renderHook(
+      () => useCatalogProductsQuery('cat-clothes', params({ sizes: ['m', 'l'] }), attributes),
+      { wrapper: createWrapper() }
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(lastSearchFilters(calls)).toContain('variants.attributes.size-clothes.key:"m","l"');
+  });
+});

--- a/src/test/catalog.integration.test.ts
+++ b/src/test/catalog.integration.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
+
+import {
+  getCategories,
+  getProductByKey,
+  getProductsByCategory,
+  getProductsByFilter,
+  getProductsTypeByCategory,
+  getSearchProducts,
+} from '../services/productService';
+import { SortDetails, SortOption } from '../components/baseComponents/SortingList/SortList.enum';
+import { CT } from './handlers';
+import { server, recordRequests } from './server';
+import { redTeeProjection, searchResponse } from './fixtures';
+
+const lastSearch = (calls: Request[]): URL => {
+  const call = [...calls].reverse().find((c) => c.url.includes('/product-projections/search'));
+  if (!call) throw new Error('no product-projections/search request was made');
+  return new URL(call.url);
+};
+
+describe('catalog + filters (CT API via MSW)', () => {
+  it('fetches the category tree', async () => {
+    const categories = await getCategories();
+    expect(categories.map((c) => c.id)).toContain('cat-clothes');
+    expect(categories).toHaveLength(3);
+  });
+
+  it('lists a category page with subtree filter, limit and offset', async () => {
+    const calls = recordRequests();
+    const { results, total } = await getProductsByCategory('cat-clothes', 2);
+
+    expect(results).toHaveLength(2);
+    expect(total).toBe(2);
+
+    const url = lastSearch(calls);
+    expect(url.searchParams.getAll('filter')).toContain('categories.id:subtree("cat-clothes")');
+    expect(url.searchParams.get('limit')).toBe('8');
+    expect(url.searchParams.get('offset')).toBe('8'); // page 2 → 1 * DEFAULT_LIMIT
+  });
+
+  it('builds attribute, price-range and sort query args for a filtered search', async () => {
+    const calls = recordRequests();
+    await getProductsByFilter(
+      'cat-clothes',
+      1,
+      [{ color: ['red', 'blue'] }, { 'size-clothes': ['m'] }],
+      [10, 30],
+      SortDetails[SortOption.PriceLowToHigh]
+    );
+
+    const filters = lastSearch(calls).searchParams.getAll('filter');
+    expect(filters).toContain('categories.id:subtree("cat-clothes")');
+    expect(filters).toContain('variants.attributes.color.key:"red","blue"');
+    expect(filters).toContain('variants.attributes.size-clothes.key:"m"');
+    // price is converted euros → cents (×100)
+    expect(filters).toContain('variants.price.centAmount:range(1000 to 3000)');
+    expect(lastSearch(calls).searchParams.get('sort')).toBe('price asc');
+  });
+
+  it('maps the name sort key to name.en', async () => {
+    const calls = recordRequests();
+    await getProductsByFilter('cat-clothes', 1, [], undefined, SortDetails[SortOption.NameAZ]);
+    expect(lastSearch(calls).searchParams.get('sort')).toBe('name.en asc');
+  });
+
+  it('passes the search term as text.en alongside the category filter', async () => {
+    const calls = recordRequests();
+    await getSearchProducts('cat-clothes', 1, 'hoodie');
+
+    const url = lastSearch(calls);
+    expect(url.searchParams.get('text.en')).toBe('hoodie');
+    expect(url.searchParams.getAll('filter')).toContain('categories.id:subtree("cat-clothes")');
+  });
+
+  it('returns the totals the server reports (pagination)', async () => {
+    server.use(
+      http.get(`${CT}/product-projections/search`, () => HttpResponse.json(searchResponse([redTeeProjection], 42)))
+    );
+    const { results, total } = await getProductsByCategory('cat-clothes', 1);
+    expect(results).toHaveLength(1);
+    expect(total).toBe(42);
+  });
+
+  it('fetches a product by key and the attributes of a category product type', async () => {
+    const product = await getProductByKey('red-tee');
+    expect(product.key).toBe('red-tee');
+
+    const attributes = await getProductsTypeByCategory('Clothes');
+    expect(attributes?.map((a) => a.name)).toEqual(expect.arrayContaining(['color', 'size-clothes']));
+  });
+});

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -1,0 +1,189 @@
+// Minimal commercetools response fixtures for MSW. Each carries only the fields
+// the services / transforms actually read (see stores/productHelpers,
+// stores/cartHelpers) — not full CT payloads. Typed loosely on purpose: the
+// network boundary is untyped JSON, and over-typing against the huge SDK types
+// adds noise without catching real bugs.
+
+export const mainCategoryClothes = {
+  id: 'cat-clothes',
+  key: 'clothes',
+  name: { en: 'Clothes' },
+  slug: { en: 'clothes' },
+  orderHint: '0.1',
+  ancestors: [],
+};
+
+export const mainCategoryBags = {
+  id: 'cat-bags',
+  key: 'bags',
+  name: { en: 'Bags' },
+  slug: { en: 'bags' },
+  orderHint: '0.2',
+  ancestors: [],
+};
+
+export const subCategoryTshirts = {
+  id: 'cat-tshirts',
+  key: 'tshirts',
+  name: { en: 'T-Shirts' },
+  slug: { en: 't-shirts' },
+  orderHint: '0.1',
+  parent: { typeId: 'category', id: 'cat-clothes' },
+  ancestors: [{ typeId: 'category', id: 'cat-clothes' }],
+};
+
+export const categoriesResponse = {
+  limit: 20,
+  offset: 0,
+  count: 3,
+  total: 3,
+  results: [subCategoryTshirts, mainCategoryBags, mainCategoryClothes],
+};
+
+const priceEUR = (centAmount: number, discounted?: number) => ({
+  id: `price-${centAmount}`,
+  value: { type: 'centPrecision', currencyCode: 'EUR', centAmount, fractionDigits: 2 },
+  ...(discounted
+    ? {
+        discounted: {
+          value: { type: 'centPrecision', currencyCode: 'EUR', centAmount: discounted, fractionDigits: 2 },
+        },
+      }
+    : {}),
+});
+
+export const redTeeProjection = {
+  id: 'prod-red-tee',
+  key: 'red-tee',
+  version: 1,
+  name: { en: 'Red Tee' },
+  description: { en: 'A red t-shirt' },
+  slug: { en: 'red-tee' },
+  categories: [{ typeId: 'category', id: 'cat-tshirts' }],
+  masterVariant: {
+    id: 1,
+    sku: 'RED-TEE-1',
+    key: 'red-tee-1',
+    prices: [priceEUR(2000)],
+    images: [{ url: 'https://img.test/red-tee.png', dimensions: { w: 100, h: 100 } }],
+    attributes: [],
+  },
+  variants: [],
+};
+
+export const blueTeeProjection = {
+  id: 'prod-blue-tee',
+  key: 'blue-tee',
+  version: 1,
+  name: { en: 'Blue Tee' },
+  description: { en: 'A blue t-shirt, on sale' },
+  slug: { en: 'blue-tee' },
+  categories: [{ typeId: 'category', id: 'cat-tshirts' }],
+  masterVariant: {
+    id: 1,
+    sku: 'BLUE-TEE-1',
+    key: 'blue-tee-1',
+    prices: [priceEUR(3000, 2500)],
+    images: [{ url: 'https://img.test/blue-tee.png', dimensions: { w: 100, h: 100 } }],
+    attributes: [],
+  },
+  variants: [],
+};
+
+export const searchResponse = (results: unknown[] = [redTeeProjection, blueTeeProjection], total = results.length) => ({
+  limit: 8,
+  offset: 0,
+  count: results.length,
+  total,
+  results,
+});
+
+export const productsListResponse = {
+  limit: 20,
+  offset: 0,
+  count: 1,
+  total: 1,
+  results: [
+    {
+      id: 'prod-red-tee',
+      key: 'red-tee',
+      version: 1,
+      masterData: {
+        current: {
+          name: { en: 'Red Tee' },
+          description: { en: 'A red t-shirt' },
+          masterVariant: redTeeProjection.masterVariant,
+          variants: [],
+        },
+      },
+    },
+  ],
+};
+
+export const productByKeyResponse = {
+  id: 'prod-red-tee',
+  key: 'red-tee',
+  version: 1,
+  masterData: {
+    current: {
+      name: { en: 'Red Tee' },
+      description: { en: 'A red t-shirt' },
+      masterVariant: redTeeProjection.masterVariant,
+      variants: [],
+    },
+  },
+};
+
+export const productTypeResponse = {
+  id: 'pt-clothes',
+  key: 'Clothes',
+  name: 'Clothes',
+  attributes: [
+    { name: 'color', label: { en: 'Color' }, type: { name: 'enum' } },
+    { name: 'size-clothes', label: { en: 'Size' }, type: { name: 'enum' } },
+    { name: 'material', label: { en: 'Material' }, type: { name: 'text' } },
+  ],
+};
+
+const lineItem = {
+  id: 'line-1',
+  productId: 'prod-red-tee',
+  name: { en: 'Red Tee' },
+  variant: { id: 1, key: 'red-tee-1', sku: 'RED-TEE-1' },
+  quantity: 2,
+  price: { value: { currencyCode: 'EUR', centAmount: 2000 } },
+  totalPrice: { currencyCode: 'EUR', centAmount: 4000 },
+  discountedPricePerQuantity: [],
+};
+
+export const emptyCart = {
+  id: 'cart-1',
+  version: 1,
+  lineItems: [],
+  totalPrice: { currencyCode: 'EUR', centAmount: 0 },
+  totalLineItemQuantity: 0,
+  discountCodes: [],
+};
+
+export const cartWithItem = {
+  id: 'cart-1',
+  version: 2,
+  lineItems: [lineItem],
+  totalPrice: { currencyCode: 'EUR', centAmount: 4000 },
+  totalLineItemQuantity: 2,
+  discountCodes: [],
+};
+
+export const meCustomer = {
+  id: 'customer-1',
+  version: 1,
+  email: 'shopper@test.dev',
+  firstName: 'Test',
+  lastName: 'Shopper',
+  addresses: [{ id: 'addr-1', country: 'DE', city: 'Berlin' }],
+};
+
+export const customerSignInResult = (cart: unknown = cartWithItem) => ({
+  customer: meCustomer,
+  cart,
+});

--- a/src/test/handlers.ts
+++ b/src/test/handlers.ts
@@ -1,0 +1,49 @@
+import { http, HttpResponse } from 'msw';
+
+import {
+  cartWithItem,
+  categoriesResponse,
+  customerSignInResult,
+  emptyCart,
+  meCustomer,
+  productByKeyResponse,
+  productTypeResponse,
+  productsListResponse,
+  searchResponse,
+} from './fixtures';
+
+// Both the CT SDK (ctClient) and the handlers read the same import.meta.env, so
+// the mocked host/projectKey always match the SDK's outgoing URL. Fallbacks keep
+// CI green when no .env is present (see vite.config test.env).
+const HOST = import.meta.env.VITE_API_URL_CLIENT ?? 'https://api.commercetools.test';
+const PROJECT = import.meta.env.VITE_PROJECT_KEY_CLIENT ?? 'test-project';
+export const CT = `${HOST}/${PROJECT}`;
+
+const hourFromNow = (): number => Date.now() + 60 * 60 * 1000;
+const token = (value: string) => HttpResponse.json({ token: value, expiresAt: hourFromNow() });
+
+// Default happy-path handlers. Tests override per-case with server.use(...).
+export const handlers = [
+  // ---- auth BFF (/api/auth/*) ----
+  http.post('/api/auth/visitor', () => token('visitor-token')),
+  http.post('/api/auth/anonymous', () => token('anon-token')),
+  http.post('/api/auth/refresh', () => token('refreshed-token')),
+  http.post('/api/auth/login', () => token('customer-token')),
+  http.post('/api/auth/logout', () => new HttpResponse(null, { status: 204 })),
+
+  // ---- commercetools API ----
+  http.get(`${CT}/categories`, () => HttpResponse.json(categoriesResponse)),
+  http.get(`${CT}/products`, () => HttpResponse.json(productsListResponse)),
+  http.get(`${CT}/products/:seg`, () => HttpResponse.json(productByKeyResponse)),
+  http.get(`${CT}/product-projections/search`, () => HttpResponse.json(searchResponse())),
+  http.get(`${CT}/product-types/:seg`, () => HttpResponse.json(productTypeResponse)),
+
+  http.get(`${CT}/me`, () => HttpResponse.json(meCustomer)),
+  http.post(`${CT}/me/login`, () => HttpResponse.json(customerSignInResult(), { status: 200 })),
+  http.post(`${CT}/me/signup`, () => HttpResponse.json(customerSignInResult(), { status: 201 })),
+
+  http.get(`${CT}/me/active-cart`, () => HttpResponse.json(cartWithItem)),
+  http.post(`${CT}/me/carts`, () => HttpResponse.json(emptyCart, { status: 201 })),
+  http.post(`${CT}/me/carts/:id`, () => HttpResponse.json(cartWithItem)),
+  http.delete(`${CT}/me/carts/:id`, () => HttpResponse.json(cartWithItem)),
+];

--- a/src/test/server.ts
+++ b/src/test/server.ts
@@ -1,0 +1,13 @@
+import { setupServer } from 'msw/node';
+
+import { handlers } from './handlers';
+
+export const server = setupServer(...handlers);
+
+// Records every outgoing request so tests can assert URL/query/body shape.
+// Listeners are removed globally in setupTests' afterEach.
+export const recordRequests = (): Request[] => {
+  const calls: Request[] = [];
+  server.events.on('request:start', ({ request }) => calls.push(request.clone()));
+  return calls;
+};

--- a/src/test/utils.tsx
+++ b/src/test/utils.tsx
@@ -1,0 +1,22 @@
+import type { ReactElement, ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// Fresh client per test, no retries/refetch — failures surface immediately
+// instead of being retried into a timeout. gcTime is left at the default: with
+// gcTime 0, a setQueryData entry written by a mutation (no active observer) is
+// garbage-collected before the assertion can read it.
+export const createTestQueryClient = (): QueryClient =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, refetchOnWindowFocus: false },
+      mutations: { retry: false },
+    },
+  });
+
+export const createWrapper = (): ((props: { children: ReactNode }) => ReactElement) => {
+  const queryClient = createTestQueryClient();
+  function QueryWrapper({ children }: { children: ReactNode }): ReactElement {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  }
+  return QueryWrapper;
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,5 +25,11 @@ export default defineConfig({
     include: ['src/**/*.test.{ts,tsx}'],
     // legacy tests assert raw CSS-module class names (CRA identity transform)
     css: { modules: { classNameStrategy: 'non-scoped' } },
+    // Deterministic, non-secret CT endpoint so MSW handlers and the SDK build
+    // identical URLs regardless of a local .env (and with none in CI).
+    env: {
+      VITE_PROJECT_KEY_CLIENT: 'test-project',
+      VITE_API_URL_CLIENT: 'https://api.commercetools.test',
+    },
   },
 });


### PR DESCRIPTION
Phase **6.1** — MSW 2 mocks for the CT API + integration tests for the three feature data-paths.

## What

- **MSW 2** (`msw@^2`) + a shared harness in `src/test/`:
  - `server.ts` — `setupServer` + a `recordRequests()` helper for asserting outgoing request shape.
  - `handlers.ts` — happy-path handlers for the auth **BFF** (`/api/auth/*`) and the **CT API** (categories, product-projections/search, product-types, products, me, me/login, me/signup, me carts).
  - `fixtures.ts` — minimal CT payloads shaped to exactly what the transforms read.
  - `utils.tsx` — per-test `QueryClient` wrapper (retries off).
- Wired into `setupTests.ts`. **Key detail:** `server.listen()` runs at setup-file eval time (not in `beforeAll`) — the CT SDK captures `httpClient: fetch` once at module load, so MSW must patch `globalThis.fetch` *before* `ctClient` imports. `onUnhandledRequest: 'error'`.
- `vite.config` `test.env` pins a deterministic, **non-secret** CT host/projectKey so handler URLs match the SDK in CI (no `.env` there).

## Tests — 29 new (70 unit/integration total)

| Suite | Covers |
|---|---|
| `catalog.integration` | subtree filter, attribute filters, price euros→cents, sort key mapping (`name`→`name.en`), `text.en` search, pagination offset, server totals, product-by-key, product-type attributes |
| `catalog-hooks.integration` | `useCategoriesQuery` transform/nesting, `useCategoryAttributesQuery`, `useCatalogProductsQuery` branch (plain / search / filter) + `select` transforms |
| `cart.integration` | active-cart 200 / 404→null / non-404 rethrow, create (EUR) / update (version+actions) / delete (version queryArg), add/clear/apply-promo mutation cache writes |
| `auth.integration` | visitor token memoization, lazy anonymous session, refresh on expiry, drop-on-refresh-failure, `loginSession`, `customerLogin` + `customerSignUp` request shaping |

> Note: the plan named `entities/*` + `shared/api`; the real layers are `services/*` + `queries/*` — these tests target those (sets up **6.2** coverage thresholds).

> Landmine documented in `phase-6.md`: the CT SDK reads `errors[0].code` on an error body, so a mock with `errors: []` is mis-reported as a network error (`statusCode 0`) — error mocks must include a populated `errors[]`.

## Gate

`tsc` clean · eslint **0 errors** (17 pre-existing warnings) · **70/70** unit+integration · **11/11** e2e (vs local `netlify dev`).