### PR TITLE
fix(a11y): form labels/aria + dark-theme contrast audit (6.4)

### DIFF
--- a/docs/refactor/PROGRESS.md
+++ b/docs/refactor/PROGRESS.md
@@ -5,12 +5,13 @@
 
 ## Current state
 
-- **Phase:** 6 — **quality consolidation, nearly done.** Merged to `develop`:
-  **6.1** MSW integration tests, **6.3** (Playwright in CI vs Netlify preview),
-  **6.4** Filter focus-trap, **6.5** README + ADRs, **6.6** dependency security.
-  **6.2** coverage thresholds done (PR open). Pending: **6.4** remainder (form
-  aria + dark-theme contrast), final close. Phase 5 (UI) **COMPLETE** — Tailwind
-  4 + Radix, engine-swap keeping the look 1:1, all parts merged.
+- **Phase:** 6 — **quality consolidation, wrapping up.** Merged to `develop`:
+  **6.1** MSW integration tests, **6.2** coverage thresholds, **6.3** Playwright
+  in CI (preview), **6.4** Filter focus-trap, **6.5** README + ADRs, **6.6**
+  dependency security. **6.4 form labels/aria done (PR open); dark-theme contrast
+  measured + documented, colours left 1:1 per user decision.** Remaining: final
+  close (PROGRESS wrap-up). Phase 5 (UI) **COMPLETE** — Tailwind 4 + Radix,
+  engine-swap keeping the look 1:1, all parts merged.
   - **Part 1 MERGED** to `develop` (PR #221) + a11y nits (PR #222): foundation,
     Footer, Header (forks merged), Card+ProductList, adaptive Filter (Filter/
     FilterMobile + Sorting/SortMobile forks gone), Catalog shell, Cart page
@@ -87,6 +88,23 @@
 | 2026-06-15 | Icons → **lucide-react**; interactive primitives → **hybrid Radix** (Slider/Dialog/Select) + native (checkbox/pagination/toast). Brand GitHub icon inlined (lucide dropped brand marks) |
 
 ## Session log
+
+### 2026-06-19 — Session 13 (phase 6.4 — form a11y + dark-theme contrast audit)
+
+- **form labels/aria (no visual change):** `RHFTextField` + `RHFSelect` set
+  `aria-invalid` and link helper text via `aria-describedby`; `RHFSelect` label
+  tied to the trigger with `aria-labelledby`; `Search`/`PromoCode` inputs got
+  accessible names, `PromoCode` error is `role="alert"`. Verified live on /login
+  (Email/Password names + `aria-invalid`). Filter/catalog/currency controls
+  already had names.
+- **dark-theme contrast: measured + documented, colours unchanged** (user chose
+  audit-only to keep the look 1:1). Findings logged in phase-6.md: input text
+  renders black (~1.12 on #121212 — preflight-off, inputs don't inherit theme
+  colour) and white-on-primary-orange CTAs (~2.85). Both need token-colour
+  changes to fix → deferred as a look-vs-a11y decision.
+- **Gate:** typecheck clean · eslint 0 errors (17 pre-existing warnings) · 98
+  unit/integration + coverage · 11 e2e.
+- **Next:** final PROGRESS wrap-up / close the refactor.
 
 ### 2026-06-19 — Session 12 (phase 6.2 — coverage thresholds)
 

--- a/docs/refactor/phase-6.md
+++ b/docs/refactor/phase-6.md
@@ -50,7 +50,28 @@ Plan reference: REFACTORING_PLAN.md §5, "Фаза 6".
         filter trigger.
   - [x] `ThemeToggle.tsx`: `aria-label="Toggle theme"` — done early (PR #222)
   - [x] `ErrorBoundary.tsx`: uses `RoutePaths.MAIN` — done early (PR #222)
-  - [ ] Remaining: broad form labels/aria audit + dark-theme contrast pass.
+  - [x] Form labels/aria audit (2026-06-19, no visual change): `RHFTextField`
+        + `RHFSelect` now set `aria-invalid` and link the helper text via
+        `aria-describedby`; `RHFSelect`'s visible label is tied to the trigger
+        with `aria-labelledby` (was a bare `<span>`); `Search` and `PromoCode`
+        inputs gained accessible names (`aria-label`) and `PromoCode`'s error is
+        an `aria-describedby` `role="alert"`. Verified live: login fields expose
+        Email/Password names + `aria-invalid`. Filter/catalog controls already
+        had names (`Size`, `Sorting`, per-colour `aria-label`, `aria-pressed`),
+        as did `SelectCurrency` and the password toggle.
+  - [~] Dark-theme contrast — **measured, documented, colours left unchanged**
+        (1:1-look constraint; user decision 2026-06-19). WCAG AA findings:
+        - **Input text renders black** (`#000`) in dark mode → ratio ~1.12 on
+          `#121212` (login/registration/search/promo/profile). Root cause:
+          Tailwind preflight is intentionally OFF, so `<input>` keeps the UA
+          default `color` instead of inheriting the theme's light text. **Most
+          impactful**; typed text is barely legible in dark mode.
+        - **White on primary orange** (`#f2760f`) buttons → ratio ~2.85 (below
+          AA 4.5); theme-independent, affects all primary CTAs.
+        - Passing (for reference): body/price text 16.7, gray labels 6.5,
+          orange links 6.6, red breadcrumb 4.8.
+        - Fixing either means changing token colours (deviates from 1:1) — left
+          for a follow-up if accessibility is prioritised over the exact look.
 - [x] **6.5** Docs (2026-06-18): README rewritten (real stack/architecture/setup/
       scripts/structure; dropped the stale CRA/MUI/MobX boilerplate). ADRs added in
       `docs/adr/`: 0001 BFF auth, 0002 TanStack Query + Zustand, 0003 Tailwind +

--- a/src/components/baseComponents/PromoCode/PromoCode.tsx
+++ b/src/components/baseComponents/PromoCode/PromoCode.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useId, useState } from 'react';
 
 import { promoCode } from '../../../constants';
 import { cn } from '../../../shared/lib/cn';
@@ -11,6 +11,7 @@ type Props = {
 const PromoCode: React.FC<Props> = ({ className, onChange }) => {
   const [code, setCode] = useState('');
   const [error, setError] = useState(false);
+  const errorId = useId();
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
     setCode(event.target.value);
@@ -38,6 +39,9 @@ const PromoCode: React.FC<Props> = ({ className, onChange }) => {
         type="text"
         value={code}
         onChange={handleChange}
+        aria-label="Promo code"
+        aria-invalid={error}
+        aria-describedby={error ? errorId : undefined}
         className="border-b border-gray bg-transparent px-1 py-1 text-content outline-none focus:border-primary"
       />
       <button
@@ -48,7 +52,11 @@ const PromoCode: React.FC<Props> = ({ className, onChange }) => {
       >
         Ok
       </button>
-      {error && <span className="text-red">Invalid promo code</span>}
+      {error && (
+        <span id={errorId} role="alert" className="text-red">
+          Invalid promo code
+        </span>
+      )}
     </div>
   );
 };

--- a/src/components/baseComponents/RHFTextField/RHFSelect.tsx
+++ b/src/components/baseComponents/RHFTextField/RHFSelect.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react';
 import { Control, Controller, FieldValues, Path } from 'react-hook-form';
 
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../Select';
@@ -23,29 +24,46 @@ const RHFSelect = <T extends FieldValues>({
   label,
   placeholder,
   className,
-}: Props<T>): React.ReactElement => (
-  <Controller
-    name={name}
-    control={control}
-    render={({ field, fieldState }) => (
-      <div className={cn('w-full', className)}>
-        {label && <span className="mb-1 block text-sm text-gray">{label}</span>}
-        <Select value={field.value ?? ''} onValueChange={field.onChange}>
-          <SelectTrigger aria-label={label} className={cn(fieldState.error && 'border-red')}>
-            <SelectValue placeholder={placeholder ?? label} />
-          </SelectTrigger>
-          <SelectContent>
-            {options.map((option) => (
-              <SelectItem key={option.value} value={option.value}>
-                {option.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <p className="mt-1 min-h-5 text-xs text-red">{fieldState.error?.message ?? ' '}</p>
-      </div>
-    )}
-  />
-);
+}: Props<T>): React.ReactElement => {
+  const labelId = useId();
+  const errorId = useId();
+
+  return (
+    <Controller
+      name={name}
+      control={control}
+      render={({ field, fieldState }) => (
+        <div className={cn('w-full', className)}>
+          {label && (
+            <span id={labelId} className="mb-1 block text-sm text-gray">
+              {label}
+            </span>
+          )}
+          <Select value={field.value ?? ''} onValueChange={field.onChange}>
+            <SelectTrigger
+              aria-label={label ? undefined : placeholder}
+              aria-labelledby={label ? labelId : undefined}
+              aria-invalid={!!fieldState.error}
+              aria-describedby={fieldState.error ? errorId : undefined}
+              className={cn(fieldState.error && 'border-red')}
+            >
+              <SelectValue placeholder={placeholder ?? label} />
+            </SelectTrigger>
+            <SelectContent>
+              {options.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p id={errorId} className="mt-1 min-h-5 text-xs text-red">
+            {fieldState.error?.message ?? ' '}
+          </p>
+        </div>
+      )}
+    />
+  );
+};
 
 export default RHFSelect;

--- a/src/components/baseComponents/RHFTextField/RHFTextField.tsx
+++ b/src/components/baseComponents/RHFTextField/RHFTextField.tsx
@@ -32,6 +32,7 @@ const RHFTextField = <T extends FieldValues>({
 }: Props<T>): React.ReactElement => {
   const [show, setShow] = useState(false);
   const id = useId();
+  const errorId = useId();
   const inputType = password ? (show ? 'text' : 'password') : type;
 
   return (
@@ -54,6 +55,9 @@ const RHFTextField = <T extends FieldValues>({
               autoComplete={autoComplete}
               onFocus={onFocus}
               value={field.value ?? ''}
+              aria-label={label ? undefined : placeholder}
+              aria-invalid={!!fieldState.error}
+              aria-describedby={fieldState.error ? errorId : undefined}
               className={cn(
                 'w-full border-b bg-transparent py-1 pr-9 outline-none transition-colors',
                 fieldState.error ? 'border-red focus:border-red' : 'border-gray focus:border-primary'
@@ -70,7 +74,9 @@ const RHFTextField = <T extends FieldValues>({
               </button>
             )}
           </div>
-          <p className="mt-1 min-h-5 text-xs text-red">{fieldState.error?.message ?? ' '}</p>
+          <p id={errorId} className="mt-1 min-h-5 text-xs text-red">
+            {fieldState.error?.message ?? ' '}
+          </p>
         </div>
       )}
     />

--- a/src/components/baseComponents/Search/Search.tsx
+++ b/src/components/baseComponents/Search/Search.tsx
@@ -46,6 +46,7 @@ const Search: React.FC<Props> = ({ className, value, onSearch }) => {
           value={text}
           onChange={handleChange}
           onKeyDown={handleKeyDown}
+          aria-label="Search products"
           className="w-full border-b border-gray bg-transparent py-1 pl-9 text-xl outline-none focus:border-primary"
         />
       </div>


### PR DESCRIPTION
Phase **6.4** remainder — form labels/aria audit + dark-theme contrast pass.

## Form a11y (no visual change)
- `RHFTextField` / `RHFSelect`: `aria-invalid` reflects validation state; helper/error text linked via `aria-describedby`.
- `RHFSelect`: visible label tied to the Radix trigger with `aria-labelledby` (was a bare `<span>`).
- `Search`, `PromoCode`: inputs gained accessible names (`aria-label`); `PromoCode` error is now `aria-describedby` + `role="alert"`.
- Already accessible (left as-is): `RHFCheckbox`/`NumberInput` (wrapping `<label>`), `SelectSize`/`Sorting`/`SelectCurrency` (`aria-label`), `FilterChip`/`FilterColorCheckBox` (`aria-pressed` + names), password toggle.

Verified live on `/login`: Email/Password fields expose their names and `aria-invalid`.

## Dark-theme contrast — measured + documented, colours unchanged
Per the 1:1-look constraint (your call), colours were **not** changed; WCAG AA findings recorded in `docs/refactor/phase-6.md`:

| element | ratio | AA |
|---|---|---|
| **input text (dark)** | ~1.12 | ✗ black text — preflight-off, inputs don't inherit the theme colour |
| **white on primary orange** `#f2760f` | ~2.85 | ✗ all primary CTAs (theme-independent) |
| body/price text | 16.7 | ✓ |
| gray labels / orange links | 6.5 / 6.6 | ✓ |
| red breadcrumb | 4.8 | ✓ |

Both failures need token-colour changes (deviating from the original look) — left as a follow-up decision.

## Gate
`tsc` clean · eslint **0 errors** (17 pre-existing warnings) · **98/98** unit+integration + coverage · **11/11** e2e.