### PR TITLE
fix(a11y): dark-theme input text + close phase 6

### DIFF
--- a/docs/refactor/PROGRESS.md
+++ b/docs/refactor/PROGRESS.md
@@ -5,13 +5,22 @@
 
 ## Current state
 
-- **Phase:** 6 — **quality consolidation, wrapping up.** Merged to `develop`:
-  **6.1** MSW integration tests, **6.2** coverage thresholds, **6.3** Playwright
-  in CI (preview), **6.4** Filter focus-trap, **6.5** README + ADRs, **6.6**
-  dependency security. **6.4 form labels/aria done (PR open); dark-theme contrast
-  measured + documented, colours left 1:1 per user decision.** Remaining: final
-  close (PROGRESS wrap-up). Phase 5 (UI) **COMPLETE** — Tailwind 4 + Radix,
-  engine-swap keeping the look 1:1, all parts merged.
+- **Phase:** 6 — **COMPLETE.** All items merged to `develop`: **6.1** MSW
+  integration tests, **6.2** coverage thresholds (80/70, enforced in CI),
+  **6.3** Playwright in CI (Netlify preview), **6.4** a11y (Filter focus-trap +
+  form labels/aria + dark-theme contrast: input-text bug fixed, rest documented
+  1:1), **6.5** README + ADRs, **6.6** dependency security. **The 7-phase
+  refactor (0→6) is done on `develop`; awaiting the final `develop`→`main`
+  merge.** Phase 5 (UI) **COMPLETE** — Tailwind 4 + Radix, engine-swap keeping
+  the look 1:1, all parts merged.
+- **Refactor outcome (0→6):** CRA→Vite 7 · React 18→19 · TS 4.9→5.9 strict ·
+  MobX→TanStack Query 5 + Zustand · Formik/Yup→RHF + zod 4 · `sdk-client-v2`→
+  `@commercetools/ts-client` v4 **+ BFF (Netlify Functions)** so the
+  clientSecret left the browser bundle · Jest/CRA→Vitest 3 + MSW 2 (98
+  unit/integration) + Playwright (11 e2e, in CI) · ESLint 8 airbnb→ESLint 9 flat ·
+  MUI 7 + SCSS → **Tailwind 4 + Radix + lucide** (one styling system, look 1:1).
+  Coverage thresholds enforced on `services/*` + `queries/*`. **Prod is still on
+  the 2023 CRA build until `main` is deployed.**
   - **Part 1 MERGED** to `develop` (PR #221) + a11y nits (PR #222): foundation,
     Footer, Header (forks merged), Card+ProductList, adaptive Filter (Filter/
     FilterMobile + Sorting/SortMobile forks gone), Catalog shell, Cart page
@@ -88,6 +97,20 @@
 | 2026-06-15 | Icons → **lucide-react**; interactive primitives → **hybrid Radix** (Slider/Dialog/Select) + native (checkbox/pagination/toast). Brand GitHub icon inlined (lucide dropped brand marks) |
 
 ## Session log
+
+### 2026-06-19 — Session 14 (phase 6 CLOSED — input-contrast fix + refactor wrap-up)
+
+- **fixed the dark-theme input bug** found in the 6.4 audit: `input, optgroup,
+  select, textarea { color: inherit }` in `tailwind.css` so fields follow the
+  theme text colour. Verified live in **both** themes (screenshots): light
+  unchanged (dark text on white), dark now readable (`#f2f2f2`, ~16.7). The
+  white-on-orange CTA contrast and a couple of fixed-colour headings are left
+  1:1 and documented (token-colour change deferred).
+- **closed the refactor:** phase 6 fully merged to `develop`; PROGRESS "Current
+  state" now records the 0→6 outcome. Only the final `develop`→`main` merge
+  remains (prod still on the 2023 CRA build until then).
+- **Gate:** typecheck clean · eslint 0 errors · 98 unit/integration + coverage ·
+  11 e2e.
 
 ### 2026-06-19 — Session 13 (phase 6.4 — form a11y + dark-theme contrast audit)
 

--- a/docs/refactor/phase-6.md
+++ b/docs/refactor/phase-6.md
@@ -42,7 +42,7 @@ Plan reference: REFACTORING_PLAN.md §5, "Фаза 6".
   - Note: the registration scenario creates a real CT customer per run (unique
     email) — inherent to e2e-against-real-CT. Phase 0 scenarios already track the
     final UI (kept green through phase 5).
-- [~] **6.4** A11y pass. Specific items from the PR #221 review (phase 5 part 1):
+- [x] **6.4** A11y pass. Specific items from the PR #221 review (phase 5 part 1):
   - [x] Filter mobile drawer (`Filter.tsx`): Esc-to-close + focus-to-close-button
         + `role="dialog"`/`aria-modal` (PR #222), and now **full focus-TRAP**
         (Tab/Shift+Tab wrap inside) + **focus-return-to-trigger** on close
@@ -59,19 +59,23 @@ Plan reference: REFACTORING_PLAN.md §5, "Фаза 6".
         Email/Password names + `aria-invalid`. Filter/catalog controls already
         had names (`Size`, `Sorting`, per-colour `aria-label`, `aria-pressed`),
         as did `SelectCurrency` and the password toggle.
-  - [~] Dark-theme contrast — **measured, documented, colours left unchanged**
-        (1:1-look constraint; user decision 2026-06-19). WCAG AA findings:
-        - **Input text renders black** (`#000`) in dark mode → ratio ~1.12 on
-          `#121212` (login/registration/search/promo/profile). Root cause:
-          Tailwind preflight is intentionally OFF, so `<input>` keeps the UA
-          default `color` instead of inheriting the theme's light text. **Most
-          impactful**; typed text is barely legible in dark mode.
+  - [x] Dark-theme contrast — measured; the one real bug fixed, the rest
+        documented and left 1:1 (user decision 2026-06-19). WCAG AA findings:
+        - **Input text rendered black in dark mode** → ratio ~1.12 on `#121212`
+          (login/registration/search/promo/profile). Root cause: preflight is
+          off, so `<input>` kept the UA default `color` instead of inheriting
+          the theme text. **FIXED** by `input, optgroup, select, textarea {
+          color: inherit }` in `tailwind.css` — light theme unchanged (text was
+          already dark), dark theme now light/readable (~16.7). Verified live in
+          both themes (screenshots).
         - **White on primary orange** (`#f2760f`) buttons → ratio ~2.85 (below
-          AA 4.5); theme-independent, affects all primary CTAs.
-        - Passing (for reference): body/price text 16.7, gray labels 6.5,
-          orange links 6.6, red breadcrumb 4.8.
-        - Fixing either means changing token colours (deviates from 1:1) — left
-          for a follow-up if accessibility is prioritised over the exact look.
+          AA 4.5); theme-independent, affects all primary CTAs. **Left as-is** —
+          fixing it changes the brand colour (deviates from 1:1); deferred as a
+          look-vs-a11y decision.
+        - Pre-existing, also left 1:1: some headings use a fixed dark colour and
+          are low-contrast on the dark theme (same token-colour tradeoff).
+        - Passing (reference): body/price 16.7, gray labels 6.5, orange links
+          6.6, red breadcrumb 4.8.
 - [x] **6.5** Docs (2026-06-18): README rewritten (real stack/architecture/setup/
       scripts/structure; dropped the stale CRA/MUI/MobX boilerplate). ADRs added in
       `docs/adr/`: 0001 BFF auth, 0002 TanStack Query + Zustand, 0003 Tailwind +
@@ -91,7 +95,8 @@ Plan reference: REFACTORING_PLAN.md §5, "Фаза 6".
         (tightly version-coupled), and `netlify-cli@26` already pins its own copies.
         Revisit when Vite/netlify-cli bump esbuild upstream.
   - Verify on GitHub that Dependabot's tracked alerts clear after merge.
-- [ ] Final `PROGRESS.md` update; close the refactor.
+- [x] Final `PROGRESS.md` update; close the refactor (2026-06-19). All of phase
+      6 merged to `develop`; refactor summary recorded in PROGRESS.md.
 
 ## Exit criteria
 

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -309,6 +309,15 @@ textarea {
   line-height: 1.15;
   margin: 0;
 }
+/* Form fields inherit the theme text colour instead of the UA default (black).
+   Preflight is off, so without this typed text stays black and is unreadable on
+   the dark theme; light theme is unaffected (its text is already dark). */
+input,
+optgroup,
+select,
+textarea {
+  color: inherit;
+}
 button,
 select {
   text-transform: none;


### PR DESCRIPTION
Closing work for phase 6.

## Fix — dark-theme input text (the one real contrast bug)
With Tailwind preflight off, `<input>` kept the UA default `color` (black), so typed text was unreadable on the dark theme (contrast ~1.12 on `#121212`).

```css
input, optgroup, select, textarea { color: inherit; }
```

Fields now follow the theme text colour. **Verified live in both themes** (screenshots): light unchanged (dark text on white), dark now readable (`#f2f2f2`, ~16.7). White-on-primary-orange CTAs and a few fixed-colour headings are left 1:1 and documented (token-colour change deferred as a look-vs-a11y call).

## Close-out
All of phase 6 is merged to `develop`:
- 6.1 MSW + integration tests · 6.2 coverage thresholds (CI-enforced) · 6.3 Playwright in CI (preview) · 6.4 a11y (focus-trap + form aria + this contrast fix) · 6.5 README/ADRs · 6.6 deps

`PROGRESS.md` now records the full 0→6 outcome and marks the refactor done. **Only the final `develop`→`main` merge remains** (prod still on the 2023 CRA build until then).

## Gate
`tsc` clean · eslint **0 errors** · **98/98** unit+integration + coverage · **11/11** e2e.