### PR TITLE
fix(ui): dark-theme token bug, search field shadow + button height

### DIFF
--- a/docs/refactor/phase-6.md
+++ b/docs/refactor/phase-6.md
@@ -72,8 +72,16 @@ Plan reference: REFACTORING_PLAN.md §5, "Фаза 6".
           AA 4.5); theme-independent, affects all primary CTAs. **Left as-is** —
           fixing it changes the brand colour (deviates from 1:1); deferred as a
           look-vs-a11y decision.
-        - Pre-existing, also left 1:1: some headings use a fixed dark colour and
-          are low-contrast on the dark theme (same token-colour tradeoff).
+        - **FIXED (follow-up)**: dark-theme `text-content` (headings, product
+          titles, prices) rendered near-black — not a colour choice but a
+          Tailwind v4 bug: the semantic `@theme` tokens (`--color-content/page/
+          component/panel/body`) were flattened to their light values at build
+          time, so `bg-*`/`text-content` utilities ignored the dark override.
+          Re-pointed those tokens in the `body[data-theme='dark']` block; light
+          theme unchanged, dark now readable (~16.7). Verified both themes.
+        - Also fixed: the Search input showed the native `appearance: textfield`
+          inset border (`appearance-none` + `border-0 border-b`) and the Search
+          button now matches the input height.
         - Passing (reference): body/price 16.7, gray labels 6.5, orange links
           6.6, red breadcrumb 4.8.
 - [x] **6.5** Docs (2026-06-18): README rewritten (real stack/architecture/setup/

--- a/src/components/baseComponents/Search/Search.tsx
+++ b/src/components/baseComponents/Search/Search.tsx
@@ -32,7 +32,7 @@ const Search: React.FC<Props> = ({ className, value, onSearch }) => {
   };
 
   return (
-    <div className={cn('flex items-center md:relative', className)}>
+    <div className={cn('flex items-stretch md:relative', className)}>
       <div className="relative flex w-full items-center">
         <Icon
           name={IconName.SEARCH}
@@ -47,13 +47,13 @@ const Search: React.FC<Props> = ({ className, value, onSearch }) => {
           onChange={handleChange}
           onKeyDown={handleKeyDown}
           aria-label="Search products"
-          className="w-full border-b border-gray bg-transparent py-1 pl-9 text-xl outline-none focus:border-primary"
+          className="w-full appearance-none rounded-none border-0 border-b border-gray bg-transparent py-1 pl-9 text-xl outline-none focus:border-primary"
         />
       </div>
       <button
         type="button"
         onClick={handleClick}
-        className="ml-4 shrink-0 rounded bg-primary px-4 py-1.5 text-white transition-colors hover:bg-primary/85"
+        className="ml-4 flex shrink-0 items-center justify-center rounded bg-primary px-4 text-white transition-colors hover:bg-primary/85"
       >
         Search
       </button>

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -170,6 +170,16 @@ body[data-theme='dark'] {
   --nav-color-dark: var(--light-white);
   --nav-color-dark-hover: var(--light-white);
   --component-bg: var(--dark);
+
+  /* Tailwind v4 flattens the semantic @theme tokens (--color-content/page/…) to
+   * their light values at build time, so the `var(--…-bg)` indirection above does
+   * NOT reach the bg-page / text-content utilities. Re-point them here so dark
+   * mode applies to those classes (text-content was rendering near-black). */
+  --color-body: var(--dark);
+  --color-page: var(--black);
+  --color-component: var(--dark);
+  --color-panel: rgba(255, 255, 255, 0.08);
+  --color-content: var(--light-white);
 }
 
 /* ───────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Display bugs spotted in live review.

## 1. Dark theme: text & component colours stuck on light values
`text-content` (headings, product titles, prices) and the `bg-*` utilities rendered with **light-theme colours in dark mode** — product titles/prices were near-black on the dark background.

Root cause: Tailwind v4 **flattens `@theme` variables at build time**. The semantic tokens (`--color-content/page/component/panel/body`) were defined as `var(--…-bg)` so they'd track the runtime dark override — but Tailwind resolved them to the *light* values statically, so the utilities never saw the dark theme. (The page background still looked right only because `body{}` reads the runtime var directly, not via a utility.)

Fix: re-point those five tokens in the `body[data-theme='dark']` block to their dark values. **Light theme is unchanged** (verified: `text-content` still `#0b0a0a`); dark theme now readable (`text-content` `#f2f2f2`, ~16.7 contrast). Verified in both themes via screenshots.

## 2. Search input — leftover native shadow/box
`<input type="search">` kept `appearance: textfield`, which draws a 2px inset border on top/left/right (the "shadow"). Added `appearance-none` + `border-0 border-b` so only the intended bottom border shows.

## 3. Search button height
The **Search** button was shorter than the input (27 vs 39px). Switched the row to `items-stretch` and centred the button label → button matches the input height (37 = 37).

## Gate
`tsc` clean · eslint **0 errors** · **98/98** unit+integration + coverage · **11/11** e2e.