### PR TITLE
fix(ui): strip native inset border from form text inputs

### DIFF
--- a/src/components/baseComponents/RHFTextField/RHFTextField.tsx
+++ b/src/components/baseComponents/RHFTextField/RHFTextField.tsx
@@ -59,7 +59,7 @@ const RHFTextField = <T extends FieldValues>({
               aria-invalid={!!fieldState.error}
               aria-describedby={fieldState.error ? errorId : undefined}
               className={cn(
-                'w-full border-b bg-transparent py-1 pr-9 outline-none transition-colors',
+                'w-full appearance-none rounded-none border-0 border-b bg-transparent py-1 pr-9 outline-none transition-colors',
                 fieldState.error ? 'border-red focus:border-red' : 'border-gray focus:border-primary'
               )}
             />


### PR DESCRIPTION
Follow-up to the search-field fix — the login/registration/profile inputs (`RHFTextField`) had the **same native `appearance: textfield` inset border** (2px on top/left/right), so they rendered as a box instead of the intended underline.

Fix: `appearance-none` + `border-0 border-b` (same as Search). Verified live on `/login`: both Email and Password fields now show only the bottom border (`top/right/left: 0`, `bottom: 1px solid`).

## Gate
`tsc` clean · eslint **0 errors** · **98/98** unit+integration + coverage · **11/11** e2e.