### PR TITLE
fix(ui): dark-theme icon buttons render black (menu/burger)

### DIFF
--- a/docs/refactor/phase-6.md
+++ b/docs/refactor/phase-6.md
@@ -80,8 +80,15 @@ Plan reference: REFACTORING_PLAN.md §5, "Фаза 6".
           Re-pointed those tokens in the `body[data-theme='dark']` block; light
           theme unchanged, dark now readable (~16.7). Verified both themes.
         - Also fixed: the Search input showed the native `appearance: textfield`
-          inset border (`appearance-none` + `border-0 border-b`) and the Search
+          inset border (`appearance-none` + `border-0 border-b`); the same applied
+          to the login/registration/profile `RHFTextField` inputs; the Search
           button now matches the input height.
+        - Also fixed: icon-only **buttons** (e.g. the mobile menu/burger) showed
+          black icons on the dark theme — buttons kept the UA default `color`
+          (preflight off). Extended the `color: inherit` reset to `button` so
+          their `currentColor` icons follow the theme (utilities like `text-white`
+          still win). Dark-theme sweep across home/catalog/product/cart/
+          registration/about/sale: 0 dark-on-dark elements remaining.
         - Passing (reference): body/price 16.7, gray labels 6.5, orange links
           6.6, red breadcrumb 4.8.
 - [x] **6.5** Docs (2026-06-18): README rewritten (real stack/architecture/setup/

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -319,9 +319,12 @@ textarea {
   line-height: 1.15;
   margin: 0;
 }
-/* Form fields inherit the theme text colour instead of the UA default (black).
-   Preflight is off, so without this typed text stays black and is unreadable on
-   the dark theme; light theme is unaffected (its text is already dark). */
+/* Form fields and buttons inherit the theme text colour instead of the UA
+   default (black). Preflight is off, so without this their text/icons stay black
+   and are invisible on the dark theme (e.g. the mobile menu icon); light theme
+   is unaffected (its text is already dark), and buttons that set an explicit
+   colour utility — text-white/text-primary — still win over this. */
+button,
 input,
 optgroup,
 select,


### PR DESCRIPTION
The mobile menu (burger) icon — and any icon-only button — rendered **black on the dark theme**.

Root cause (same family as the input/text-content fixes): with Tailwind preflight off, `<button>` keeps the UA default `color: buttontext` (black) instead of inheriting, so the lucide icon's `currentColor` resolved to black. The button sat in a light-text header, but its own `color` overrode the inherited theme colour.

Fix: extend the existing `color: inherit` reset to `button`. Icon `currentColor` now follows the theme; buttons with an explicit colour utility (`text-white`/`text-primary`) still win, so primary CTAs are unchanged. Light theme unaffected (inherited ≈ the old UA black).

## Dark-theme sweep
Scanned **home / catalog / product / cart / registration / about / sale** for near-black text/icons on dark backgrounds → **0 remaining**. Menu icon verified light (`rgb(242,242,242)`); screenshot confirms.

## Gate
`tsc` clean · eslint **0 errors** · **98/98** unit+integration + coverage · **11/11** e2e.