### PR TITLE
fix(ui): promo input, dark qty input, non-blue slider arrows

### DIFF
--- a/src/components/baseComponents/NumberInput/NumberInput.tsx
+++ b/src/components/baseComponents/NumberInput/NumberInput.tsx
@@ -23,7 +23,7 @@ const NumberInput: React.FC<Props> = ({ value, onChange, min, max, label, classN
         min={min}
         max={max}
         onChange={handleChange}
-        className="w-full rounded border border-gray px-3 py-2 outline-none focus:border-primary"
+        className="w-full rounded border border-gray bg-transparent px-3 py-2 outline-none focus:border-primary"
       />
     </label>
   );

--- a/src/components/baseComponents/PromoCode/PromoCode.tsx
+++ b/src/components/baseComponents/PromoCode/PromoCode.tsx
@@ -42,7 +42,7 @@ const PromoCode: React.FC<Props> = ({ className, onChange }) => {
         aria-label="Promo code"
         aria-invalid={error}
         aria-describedby={error ? errorId : undefined}
-        className="border-b border-gray bg-transparent px-1 py-1 text-content outline-none focus:border-primary"
+        className="appearance-none rounded-none border-0 border-b border-gray bg-transparent px-1 py-1 text-content outline-none focus:border-primary"
       />
       <button
         type="button"

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -431,9 +431,16 @@ svg:not(:root) {
   overflow: hidden;
   -webkit-line-clamp: 2;
 }
+/* Swiper navigation arrows: override Swiper's default blue theme colour
+   (--swiper-theme-color #007aff) with white + a soft shadow so they read on any
+   slide background. The colour is on the button element, not ::after. */
+.swiper-button-prev,
+.swiper-button-next {
+  color: var(--light-white);
+  --swiper-navigation-color: var(--light-white);
+}
 .swiper-button-prev::after,
 .swiper-button-next::after {
-  color: var(--light-white);
   text-shadow: 1px 1px 1px var(--gray);
 }
 .swiper-scrollbar-drag {


### PR DESCRIPTION
Three more spotted in dark-theme review.

## 1. Promo-code input (cart)
Still had the native `appearance: textfield` inset border (box). Same fix as the other inputs: `appearance-none` + `border-0 border-b` → clean underline.

## 2. Product quantity input — white digit on white
`NumberInput` had no `bg-*` class, so it kept the UA white field background. After the global `color: inherit` fix the digit became light → **invisible on white in dark theme**. Added `bg-transparent` so the dark page shows through and the digit is readable (light theme unchanged — page is already light).

## 3. Slider arrows were blue
Swiper's default `--swiper-theme-color` (`#007aff`) coloured the nav arrows. The old CSS targeted `::after` (not the coloured node). Now set `color` + `--swiper-navigation-color: var(--light-white)` on the button elements → **white** arrows with a soft shadow, visible on every slide (hero + product gallery). Say the word if you'd prefer another colour.

Verified live in dark theme (screenshot): promo underline, quantity `1` readable, white arrows.

## Gate
`tsc` clean · eslint **0 errors** · **98/98** unit+integration + coverage · **11/11** e2e.