### PR TITLE
chore(deps): clear undici + http-proxy-middleware high CVEs (dev-only)

### DIFF
--- a/docs/refactor/phase-6.md
+++ b/docs/refactor/phase-6.md
@@ -115,6 +115,14 @@ Plan reference: REFACTORING_PLAN.md §5, "Фаза 6".
         look/behaviour 1:1.
   - [x] **moderate** `@opentelemetry/core`, `micromatch`, `yaml`: cleared via
         `overrides` (`@opentelemetry/core ^2.8.0`, `micromatch ^4.0.8`, `yaml ^2.8.3`).
+  - [x] **high (post-refactor, 2026-06-21)** — Dependabot flagged two **dev-only,
+        transitive** highs after a fresh advisory batch: `undici` (≤7.27.2, via
+        **jsdom** = the Vitest DOM env) and `http-proxy-middleware` (3.0.4–3.0.6,
+        via **netlify-cli** = local dev / e2e). Neither is in the production
+        bundle. Cleared via `overrides` (`undici ^7.28.0` — stays in jsdom's `^7`
+        line; `http-proxy-middleware ^3.0.7` — satisfies netlify-cli's `^3.0.5`).
+        `npm audit`: 2 high → **0 high**; 98 unit + 11 e2e green (e2e exercises
+        `netlify dev`, confirming the proxy bump is safe).
   - [~] **low** `esbuild` (9×, transitive via netlify-cli internals + Vite): NOT
         patched. Accepted residual risk — advisory is a **Windows-only dev-server
         file-read**, build-time only, **not in the production bundle**; we build on

--- a/package-lock.json
+++ b/package-lock.json
@@ -14683,9 +14683,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.6.tgz",
-      "integrity": "sha512-jhO3QfahaHWfQjEnyGW0vpYIYaXcnA6FEfehrBthOokGppvmI6zcV+1yb6TWn3vyeh8yQUoEqH51DNHOCjivxg==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.7.tgz",
+      "integrity": "sha512-iwbQltVlx8bCrqePUM8C+hllHvdawVhQJaLrj1X7qllkvFQdXFsr16pW/mo9+JDVjN+QO2XUx9jd8SmoFkE5qw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -23000,9 +23000,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
-      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,8 @@
     "@opentelemetry/api": "1.9.1",
     "@opentelemetry/core": "^2.8.0",
     "micromatch": "^4.0.8",
-    "yaml": "^2.8.3"
+    "yaml": "^2.8.3",
+    "undici": "^7.28.0",
+    "http-proxy-middleware": "^3.0.7"
   }
 }


### PR DESCRIPTION
Dependabot emailed about a vulnerable **`undici`** in `package-lock.json`. Investigated and cleared it (plus a second high in the same dev tooling).

## What it was
Two **dev-only, transitive** high-severity advisories from a fresh advisory batch — **neither ships in the production bundle**:

| Package | Range | Comes from | Role |
|---|---|---|---|
| `undici` | ≤ 7.27.2 | `jsdom` | Vitest DOM test env |
| `http-proxy-middleware` | 3.0.4–3.0.6 | `netlify-cli` | local `netlify dev` / e2e |

The email referenced `undici`; it surfaced now because the lockfile update in phase 6 bumped `undici` to 7.27.2 (within the newly-published advisory range).

## Fix
Pin patched versions via `overrides` (same approach as the 6.6 moderate fixes):
- `undici ^7.28.0` — stays in jsdom's `^7.25.0` line
- `http-proxy-middleware ^3.0.7` — satisfies netlify-cli's `^3.0.5`

`npm audit`: **2 high → 0 high** (the 9 remaining lows are the dev-only `esbuild` advisories explicitly accepted in 6.6).

## Gate
`tsc` clean · eslint **0 errors** · **98/98** unit + coverage · **11/11** e2e (boots `netlify dev` → confirms the proxy bump is safe) · `build` OK.

> Note: production was unaffected the whole time — these are test/dev tooling only.